### PR TITLE
Bump version to 0.1.1

### DIFF
--- a/md2pptx/__init__.py
+++ b/md2pptx/__init__.py
@@ -5,6 +5,6 @@
 使う場合は parser.parse_file() で Deck を得て render.build() で描画できる．
 """
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 
 __all__ = ["__version__"]


### PR DESCRIPTION
## 概要
`md2pptx/__init__.py` の `__version__` を `0.1.0` → `0.1.1` に更新します（`pyproject.toml` は
この値を参照する dynamic version なので変更不要）。

## 背景
PR #6 で front matter のタイトルスライド（`subtitle` / `author` / `affiliation`）でも相対
フォントサイズ記法 `{+N}` / `{-N}` が使えるようになったため、リリースとしてパッチバージョンを上げます。

## 品質確認
- `import md2pptx` → `__version__== "0.1.1"` を確認
- `python3 -m md2pptx --help` 正常
- 差分はバージョン 1 行のみ