### PR TITLE
Bump version to 0.2.0

### DIFF
--- a/md2pptx/__init__.py
+++ b/md2pptx/__init__.py
@@ -5,6 +5,6 @@
 使う場合は parser.parse_file() で Deck を得て render.build() で描画できる．
 """
 
-__version__ = "0.1.1"
+__version__ = "0.2.0"
 
 __all__ = ["__version__"]


### PR DESCRIPTION
## 概要
`md2pptx/__init__.py` の `__version__` を `0.1.1` → `0.2.0` に更新します（`pyproject.toml` は
この値を参照する dynamic version なので変更不要）。

## 背景
PR #9 で画像埋め込み機能（jpg/png。ショートハンド／フェンス記法、サイズ・crop・align・caption 対応）が
main に入りました。表・フロー図に並ぶ後方互換の新機能のため、semver に従い minor を上げます。

## 品質確認
- `import md2pptx` → `__version__ == "0.2.0"` を確認
- 差分はバージョン 1 行のみ