### PR TITLE
fix: allocate fixed-size slots to flow ellipsis nodes

### DIFF
--- a/md2pptx/__init__.py
+++ b/md2pptx/__init__.py
@@ -5,6 +5,6 @@
 使う場合は parser.parse_file() で Deck を得て render.build() で描画できる．
 """
 
-__version__ = "0.9.0"
+__version__ = "0.9.1"
 
 __all__ = ["__version__"]

--- a/md2pptx/flow.py
+++ b/md2pptx/flow.py
@@ -198,24 +198,34 @@ def _plan_horizontal(plan, flow, left, top, width, height, cap_reserve):
     nodes = flow.nodes
     n = len(nodes)
     gx = _emu(0.65)
-    bw = (width - (n - 1) * gx) // n
-    bw = max(_emu(1.1), min(_emu(2.4), bw))
+    # 省略記号は「…」1 文字の注記なので box と同じ幅は不要．固定幅で確保し，
+    # 残りをすべて box に配分する（省略記号を挟んでも box が縮まないように）．
+    ne = sum(1 for node in nodes if node.kind == "ellipsis")
+    nb = n - ne
+    ew = _emu(0.4)
+    if nb:
+        bw = (width - (n - 1) * gx - ne * ew) // nb
+        bw = max(_emu(1.1), min(_emu(2.4), bw))
+    else:
+        bw = ew
     bh = min(_emu(1.4), int((height - cap_reserve) * 0.7))
     bh = max(_emu(0.6), bh)
-    total = n * bw + (n - 1) * gx
+    total = nb * bw + ne * ew + (n - 1) * gx
     startx = left + (width - total) // 2
     # box＋キャプションのまとまりを縦中央に置く．
     group_h = bh + cap_reserve
     by = top + max(0, (height - group_h) // 2)
 
     centers = []
-    for i, node in enumerate(nodes):
-        bl = startx + i * (bw + gx)
+    bl = startx
+    for node in nodes:
+        w = ew if node.kind == "ellipsis" else bw
         if node.kind == "ellipsis":
-            plan["ellipses"].append((node.label or "…", bl, by, bw, bh))
+            plan["ellipses"].append((node.label or "…", bl, by, w, bh))
         else:
-            plan["boxes"].append((node, bl, by, bw, bh))
-        centers.append((bl, bl + bw // 2, bl + bw, by + bh // 2))
+            plan["boxes"].append((node, bl, by, w, bh))
+        centers.append((bl, bl + w // 2, bl + w, by + bh // 2))
+        bl += w + gx
 
     for e in flow.edges:
         if not (0 <= e.src < n and 0 <= e.dst < n):
@@ -236,21 +246,30 @@ def _plan_vertical(plan, flow, left, top, width, height, cap_reserve):
     n = len(nodes)
     gy = _emu(0.35)
     avail = height - cap_reserve
-    bh = (avail - (n - 1) * gy) // n
-    bh = max(_emu(0.6), min(_emu(1.2), bh))
+    # 横並びと同じく，省略記号は 1 行分の固定高で確保して残りを box に配分する．
+    ne = sum(1 for node in nodes if node.kind == "ellipsis")
+    nb = n - ne
+    eh = _emu(0.35)
+    if nb:
+        bh = (avail - (n - 1) * gy - ne * eh) // nb
+        bh = max(_emu(0.6), min(_emu(1.2), bh))
+    else:
+        bh = eh
     bw = min(_emu(3.2), int(width * 0.5))
     bx = left + (width - bw) // 2
-    total = n * bh + (n - 1) * gy
+    total = nb * bh + ne * eh + (n - 1) * gy
     starty = top + max(0, (avail - total) // 2)
 
     centers = []
-    for i, node in enumerate(nodes):
-        bt = starty + i * (bh + gy)
+    bt = starty
+    for node in nodes:
+        h = eh if node.kind == "ellipsis" else bh
         if node.kind == "ellipsis":
-            plan["ellipses"].append((node.label or "…", bx, bt, bw, bh))
+            plan["ellipses"].append((node.label or "…", bx, bt, bw, h))
         else:
-            plan["boxes"].append((node, bx, bt, bw, bh))
-        centers.append((bx + bw // 2, bt, bt + bh))
+            plan["boxes"].append((node, bx, bt, bw, h))
+        centers.append((bx + bw // 2, bt, bt + h))
+        bt += h + gy
 
     for e in flow.edges:
         if not (0 <= e.src < n and 0 <= e.dst < n):

--- a/md2pptx/render.py
+++ b/md2pptx/render.py
@@ -552,11 +552,13 @@ class Renderer:
         return shp
 
     def note(self, slide, l, t, w, h, text, size, tc=None, bold=False,
-             align=PP_ALIGN.LEFT):
+             align=PP_ALIGN.LEFT, anchor=None):
         """注記用テキストボックスを描く（キャプション・矢印ラベル・省略記号）．"""
         tb = slide.shapes.add_textbox(l, t, w, h)
         tf = tb.text_frame
         tf.word_wrap = True
+        if anchor is not None:
+            tf.vertical_anchor = anchor
         pa = tf.paragraphs[0]
         pa.alignment = align
         pa.text = text
@@ -614,8 +616,10 @@ class Renderer:
             self.box(slide, bl, bt, bw, bh, node.label, tc,
                      sub=node.sublabel or None, fsize=bsz, ssize=bsz)
         for label, bl, bt, bw, bh in plan["ellipses"]:
+            # 省略記号スロットは固定幅／固定高（flow.py）なので上下中央に置き，
+            # 隣接する矢印との重なりを避ける．
             self.note(slide, bl, bt, bw, bh, label, bsz, tc=self.T2, bold=True,
-                      align=PP_ALIGN.CENTER)
+                      align=PP_ALIGN.CENTER, anchor=MSO_ANCHOR.MIDDLE)
         # ノード間のすき間に塗りつぶしのブロック矢印を置く（太さは box 高に比例）．
         box_h_emu = boxes[0][4] if boxes else Inches(1.0)
         thick = int(box_h_emu * 0.34)


### PR DESCRIPTION
## 概要

flow 図の省略記号ノード `[…]` に box と同じ均等幅が割り当てられるため、省略記号を挟むと box が縮んでラベルが折り返す問題を修正する。

Resolves #25

## 変更内容

- `flow.py` `_plan_horizontal`: 省略記号に固定幅 0.4in を確保し、残り幅を box だけに配分（`bw = (width - (n-1)*gx - ne*ew) // nb`）。ノードごとの幅で座標を前進させる方式に変更
- `flow.py` `_plan_vertical`: 同様に省略記号を固定高 0.35in とし、残り高を box に配分
- `render.py` `note()`: `anchor` 引数を追加し、省略記号の描画を上下中央アンカーに。固定スロット化で「…」のグリフ（ベースライン寄り）が tb の隣接矢印と重なる問題を回避し、lr では矢印と同じ高さに揃う

## 検証

- 座標プランの幾何検証スクリプト（純 Python、pptx 非依存）: issue の 5 ノード実例で省略記号幅 0.4in・box 幅 1.68in→2.00in、省略記号なしの図は従来と同一幅、tb の固定高、ノード重なりなし・矢印正方向、省略記号のみの端ケースで例外なし — すべて成功
- 実ビルド検証（md2pptx → ppt2pdf → 目視）: issue の 5 ノード実例で「0th-draft」が折り返さず 1 行で収まり、「→ … →」が一直線に整列。tb でも「…」が矢印間に収まることを確認