### PR TITLE
build!: require Python 3.11 or newer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,8 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.14"
-      # mypy 2.x は 3.10 未満を解析対象にできないため，型チェックは新しい処理系で
-      # 1 回だけ走らせる．最古 3.9 の担保は下の generate ジョブが受け持つ．
+      # mypy は pyproject の python_version（= サポート最古）として解析するので，
+      # 実行する処理系は 1 つで足りる．
       - run: pip install -e ".[dev]"
       - run: mypy
 
@@ -28,15 +28,15 @@ jobs:
       fail-fast: false
       matrix:
         # 下限は pyproject の requires-python，上限は開発機の版．
-        python-version: ["3.9", "3.14"]
+        python-version: ["3.11", "3.14"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - run: pip install -e .
-      # import が通るだけでなく実際に pptx を生成させる．3.9 と 3.14 で出力が
-      # 一致することは実測済みなので，生成まで通すほうが保証が強い．
+      # mypy が通ることと実際に動くことは別（#32 では cli.py の future import 欠落を
+      # 実行側だけが捕まえた）．import 確認に留めず生成まで通し，出力も検査する．
       - run: md2pptx example.md --theme OfficeTheme.pptx -o out.pptx
       - name: Check the deck was produced as expected
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,9 +61,10 @@ python3 -m md2pptx.parser
 環境は python-pptx 1.0.2 / PyYAML 6 で検証。
 
 CI（`.github/workflows/ci.yml`）は 2 ジョブ。`typecheck` が mypy を 1 回、`generate` が
-**3.9 と 3.14 のマトリクス**で `example.md` の生成まで通す。mypy 2.x は 3.10 未満を解析対象に
-できないため、`requires-python = ">=3.9"` の担保は後者の実行が受け持つ（PEP 604 の `|` を
-実行時に評価する書き方などは 3.9 で実際に落ちる）。
+**3.11 と 3.14 のマトリクス**で `example.md` の生成まで通す。mypy は `pyproject.toml` の
+`python_version`（= サポート最古）として解析するので実行処理系は 1 つで足りるが、
+**実行マトリクスは別途必要**。mypy が通ることと実際に動くことは別で、#32 では
+`cli.py` の future import 欠落を実行側だけが捕まえた。
 
 ## 変更の検証（重要）
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -228,9 +228,8 @@ class Image:                 # ![](){opts} / ```image 由来
     caption: str | None = None
     overflow: bool | None = None  # None=スライドの @overflow に従う
 
-# スライド本文を構成するブロック。実行時に評価される別名なので
-# Python 3.9 を切らないよう Union で書く（`|` は 3.10 以降）
-Block = Union[Line, Table, Flow, Image]
+# スライド本文を構成するブロック
+Block = Line | Table | Flow | Image
 
 @dataclass
 class Slide:

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ input.md    ┘
 
 ## 必要環境
 
-- Python 3.9+
+- Python 3.11+
 - [python-pptx](https://python-pptx.readthedocs.io/) 1.0.2（インストール時に自動導入）
 - [PyYAML](https://pyyaml.org/)（同上）
 

--- a/md2pptx/ir.py
+++ b/md2pptx/ir.py
@@ -13,7 +13,7 @@ DESIGN.md §4 に対応．外部依存を持たない（python-pptx 等は impor
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Literal, Union
+from typing import Literal
 
 # 水平寄せ．表の列・画像の配置で共通に使う．
 Align = Literal["left", "center", "right"]
@@ -193,8 +193,7 @@ class Image:
 
 
 # スライド本文を構成するブロック．parser が出現順に並べ，render が型で分岐する．
-# Python 3.9 を切らないため実行時に評価される別名は Union で書く（`|` は 3.10 以降）．
-Block = Union[Line, Table, Flow, Image]
+Block = Line | Table | Flow | Image
 
 
 @dataclass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "md2pptx"
 dynamic = ["version"]
 description = "Markdown と PowerPoint テーマ（thmx/pptx）から発表スライド（pptx）を生成するツール"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.11"
 license = "MIT"
 license-files = ["LICENSE"]
 authors = [{ name = "Toshihiko SHIMOKAWA" }]
@@ -39,9 +39,8 @@ version = { attr = "md2pptx.__version__" }
 
 [tool.mypy]
 files = ["md2pptx"]
-# python_version は指定しない：mypy 2.x は 3.10 未満を解析対象にできない
-# （"Python 3.9 is not supported" で拒否される）．最古 3.9 の担保は CI の
-# 実行マトリクス（3.9 で実際に生成まで通す）が受け持つ．
+# サポート最古の版として解析する（requires-python と揃える）．
+python_version = "3.11"
 warn_unused_ignores = true
 warn_redundant_casts = true
 # 未注釈の関数の中身も見る（描画ヘルパーは注釈が薄いので取りこぼしを減らす）．


### PR DESCRIPTION
Resolves #36

## 背景

`requires-python = ">=3.9"` を宣言していたが、**Python 3.9 は 2025-10-31 に EOL**
（[devguide](https://devguide.python.org/versions/)）。セキュリティ修正がもう出ない版を
公式のサポート下限にしていた。

しかもこの下限は積極的に選んだものではなかった。依存側は要求していない:

| パッケージ | 導入版 | `Requires-Python` |
|---|---|---|
| python-pptx | 1.0.2 | `>=3.8` |
| PyYAML | 6.0.3 | `>=3.8` |

**3.10 でなく 3.11** にしたのは、3.10 自身が 2026-10（3 か月後）に EOL を迎えるため。
3.11 は 2027-10 まで。

## 変更内容

### 1. 宣言と型チェッカ設定（`pyproject.toml`）

```diff
-requires-python = ">=3.9"
+requires-python = ">=3.11"

 [tool.mypy]
 files = ["md2pptx"]
-# python_version は指定しない：mypy 2.x は 3.10 未満を解析対象にできない…
+# サポート最古の版として解析する（requires-python と揃える）．
+python_version = "3.11"
```

**#32 で払っていたコストが 1 つ消えた。** mypy 2.x は 3.10 未満を解析できず
（`Python 3.9 is not supported` で拒否）、宣言した下限を静的に検証できないため CI の実行で
代替していた。今は設定 1 行で本物の検査になっている。

### 2. `Block` を PEP 604 へ（`md2pptx/ir.py`）

```diff
-# Python 3.9 を切らないため実行時に評価される別名は Union で書く（`|` は 3.10 以降）．
-Block = Union[Line, Table, Flow, Image]
+Block = Line | Table | Flow | Image
```

`Union` の import も落とした（`Literal` は残る）。これは**実行時に評価される代入式**なので
3.9 では `|` が使えず、そのためだけに `Union` で書いていたもの。

### 3. CI マトリクス（`.github/workflows/ci.yml`）

`["3.9", "3.14"]` → `["3.11", "3.14"]`。

**`generate` をマトリクスのまま残した**のは意図的。mypy が通ることと実際に動くことは別で、
#32 では `cli.py` の future import 欠落を**実行側だけ**が捕まえた。その経緯をコメントに残している。

### 4. ドキュメント

`README.md`（Python 3.11+）、`CLAUDE.md`（CI の説明）、`DESIGN.md` §4 の IR スケッチ。

## 切り捨てる環境

**RHEL 9 系（Rocky / Alma）のシステム Python 3.9**。これが本 PR の唯一の意図的なトレードオフで、
#36 で前提として合意済み。

## 検証

- **mypy 0 件**（`python_version = "3.11"` を設定した状態で）
- **下限が実際に効いている**ことを確認:
  ```
  $ pip install -e .        # 3.9.25 の venv で
  ERROR: Package 'md2pptx' requires a different Python: 3.9.25 not in '>=3.11'
  ```
- **出力は不変**。`example.pptx` を再生成し、変更前の構造ダンプ（図形種別・座標・サイズ・
  テキスト・ノート）と完全一致。14 枚・ノート付き 2 枚
- **3.12 と 3.14 の出力が完全一致**。`Block` が `types.UnionType` として解決され、
  `typing.get_args` は 4 メンバを返す（3.14 では 3.14 の Union 統合により `Union` と表示されるが等価）
- **DESIGN.md スケッチと `ir.py` の突き合わせ**（#30 以来の機械的検証）: 全 11 クラスで
  フィールド名・型・必須/任意が一致、`Align` / `Block` も一致
- `python3 -m md2pptx.parser` の自己検証が通ること
- リポジトリ内に `3.9` への言及が残っていないこと（grep で確認）

なお **3.11 そのものはローカルに無い**ため（mise は 3.12/3.13/3.14）、実行検証は 3.12 で行った。
下限ちょうどの 3.11 は本 PR の `generate (3.11)` ジョブが実物を回す。

## 影響

- #35（`disallow_untyped_defs`）の注意書きのうち「future import が無いモジュールに `|` 注釈を
  書くと 3.9 で落ちる」制約が不要になり、作業が素直になる
- #33 / #34 には影響しない
