### PR TITLE
refactor: type render.py's block lists via an ObjectBlock alias

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -228,8 +228,10 @@ class Image:                 # ![](){opts} / ```image 由来
     caption: str | None = None
     overflow: bool | None = None  # None=スライドの @overflow に従う
 
-# スライド本文を構成するブロック
-Block = Line | Table | Flow | Image
+# 帯へ座標配置するブロック（地の文と違い本文プレースホルダへは入らない）
+ObjectBlock = Table | Flow | Image
+# スライド本文を構成するブロック（平坦化され Line | Table | Flow | Image と同一）
+Block = Line | ObjectBlock
 
 @dataclass
 class Slide:

--- a/md2pptx/ir.py
+++ b/md2pptx/ir.py
@@ -192,8 +192,14 @@ class Image:
     overflow: bool | None = None
 
 
+# 帯（中央領域）へ座標配置するブロック．地の文（Line）と違い，本文プレースホルダ
+# ではなく矩形に直接置かれる．render の _stack_objects / _obj_weight はこの 3 種
+# だけを扱う（Line を渡すと属性が無く落ちる）．
+ObjectBlock = Table | Flow | Image
+
 # スライド本文を構成するブロック．parser が出現順に並べ，render が型で分岐する．
-Block = Line | Table | Flow | Image
+# Union は平坦化されるので Line | Table | Flow | Image と同一．
+Block = Line | ObjectBlock
 
 
 @dataclass

--- a/md2pptx/render.py
+++ b/md2pptx/render.py
@@ -36,7 +36,9 @@ from pptx.enum.shapes import MSO_SHAPE
 from pptx.oxml.ns import qn
 from pptx.util import Inches, Pt
 
-from .ir import Deck, Slide, TitleSlide, Line, Table, Flow, Image
+from .ir import (
+    Block, Deck, Flow, Image, Line, ObjectBlock, Slide, Table, TitleSlide,
+)
 from .flow import plan_flow
 
 
@@ -1039,7 +1041,7 @@ class Renderer:
                 self._apply_autofit(tf, scale, default_autofit)
 
     # ----------------------------------------------------- 描画ユーティリティ
-    def _append_lines(self, tf, line_blocks, first, default_num_color,
+    def _append_lines(self, tf, line_blocks: list[Line], first, default_num_color,
                       default_size_delta=None):
         """Line 列を text_frame に段落として追記する（採番／no_bullet を適用）．
 
@@ -1070,7 +1072,8 @@ class Renderer:
             self._apply_size_delta(p, blk.level, delta)
         return first
 
-    def _fill_lines(self, tf, line_blocks, default_num_color, default_size_delta=None):
+    def _fill_lines(self, tf, line_blocks: list[Line], default_num_color,
+                    default_size_delta=None):
         """Line 列を text_frame の段落として流し込む（先頭から）．"""
         self._append_lines(tf, line_blocks, True, default_num_color,
                            default_size_delta)
@@ -1299,7 +1302,7 @@ class Renderer:
             return Line(text=t, kind="plain")
         return Line(text=t, kind="bullet")
 
-    def _obj_weight(self, obj):
+    def _obj_weight(self, obj: ObjectBlock):
         """オブジェクト（Table / Flow / Image）の縦方向の重み（高さ配分用）．"""
         if isinstance(obj, Flow):
             return max(4, len(obj.nodes) + 2)
@@ -1309,7 +1312,8 @@ class Renderer:
             return 8 + (1 if obj.caption else 0)
         return max(2, len(obj.rows) + (1 if obj.header else 0))
 
-    def _stack_objects(self, slide, objects, left, top, width, height, col_ratios,
+    def _stack_objects(self, slide, objects: list[ObjectBlock], left, top, width,
+                       height, col_ratios,
                        slide_overflow=False, has_prose_after=False):
         """Table / Flow / Image を矩形領域内に重みづけで縦に積んで座標配置する．
 
@@ -1336,7 +1340,7 @@ class Renderer:
                                   has_prose_after=has_prose_after)
             y += seg_h + gap
 
-    def _render_stacked(self, slide, blocks, default_num_color, scale,
+    def _render_stacked(self, slide, blocks: list[Block], default_num_color, scale,
                         default_autofit, col_ratios, default_size_delta=None,
                         slide_overflow=False):
         """表／図を含むスライドを描画する．
@@ -1352,7 +1356,8 @@ class Renderer:
                                   default_num_color, scale, default_autofit,
                                   col_ratios, default_size_delta, slide_overflow)
 
-    def _render_stacked_into(self, slide, blocks, body, left, top, width, height,
+    def _render_stacked_into(self, slide, blocks: list[Block], body, left, top,
+                             width, height,
                              default_num_color, scale, default_autofit, col_ratios,
                              default_size_delta=None, slide_overflow=False):
         """``blocks`` を矩形 (left, top, width, height) 内へスタック描画する．
@@ -1364,10 +1369,9 @@ class Renderer:
         """
         # 地の文（前後）とオブジェクト（表・図）に分ける．
         # Flow の note(top)/note(bottom) も地の文としてプレースホルダへ回す．
-        # 地の文は Line，objects は Table/Flow/Image（帯に座標配置するブロック）．
-        prose_before: list = []
-        objects: list = []
-        prose_after: list = []
+        prose_before: list[Line] = []
+        objects: list[ObjectBlock] = []
+        prose_after: list[Line] = []
         seen_obj = False
         for b in blocks:
             if isinstance(b, (Table, Flow, Image)):


### PR DESCRIPTION
Resolves #33

## 背景

`_render_stacked_into` はブロック列を 3 つのバケツに振り分けるが、いずれも素の `list` で
**何が入るか型で守られていなかった**。`blocks` / `line_blocks` を受け取る 4 つの関数も未注釈だった。

## Issue の想定から変えた点

Issue 本文では `objects` も `Block` で受ける案を挙げていた（「過剰に細分化しない」）。
しかし実装を確認したところ、**`objects` は `Line` を受け付けられない**ことが分かった:

```python
def _obj_weight(self, obj):
    if isinstance(obj, Flow):  ...
    if isinstance(obj, Image): ...
    return max(2, len(obj.rows) + (1 if obj.header else 0))   # ← Table 前提
```

`_stack_objects` も Flow / Image / else-Table でディスパッチしており、`Line` を渡すと
描画されずに **AttributeError** になる。「地の文（本文プレースホルダへ）」と
「オブジェクト（帯に座標配置）」の区別は**スタック配置の設計そのもの**なので、名前を与えた:

```python
ObjectBlock = Table | Flow | Image
Block = Line | ObjectBlock      # union は平坦化されるので Line | Table | Flow | Image と同一
```

`Block` の意味は一切変わらない（`typing.get_args` が 4 メンバを返すことを確認済み）。

## 変更内容

| 箇所 | 変更後 |
|---|---|
| `render.py:1368-1370` | `prose_before` / `prose_after` → `list[Line]`、`objects` → `list[ObjectBlock]` |
| `_render_stacked` / `_render_stacked_into` | `blocks: list[Block]` |
| `_append_lines` / `_fill_lines` | `line_blocks: list[Line]` |
| `_stack_objects` / `_obj_weight` | `objects: list[ObjectBlock]` / `obj: ObjectBlock` |
| `ir.py` | `ObjectBlock` を追加、`Block` を `Line \| ObjectBlock` に |
| `DESIGN.md` §4 | スケッチを同期 |

## 検証

**注釈が形骸化していないことを実際に確認した**。以下はいずれも変更前は素通りしていたが、今は mypy が弾く:

```
error: Argument 1 to "append" of "list" has incompatible type "Line"; expected "Table | Flow | Image"
error: Argument 1 to "append" of "list" has incompatible type "Table"; expected "Line"
error: Argument 1 to "_obj_weight" of "Renderer" has incompatible type "Line"; expected "Table | Flow | Image"
```

その他:

- `mypy` が **0 件**
- **出力は不変**。`example.pptx` を再生成し、変更前の構造ダンプ（図形種別・座標・サイズ・
  テキスト・ノート）と完全一致。14 枚・ノート付き 2 枚
- **DESIGN.md スケッチと `ir.py` の突き合わせ**（#30 以来の機械的検証）: 全 11 クラス一致に加え、
  `Align` / `ObjectBlock` / `Block` も一致。`Block` が 4 メンバのままであることも確認
- `python3 -m md2pptx.parser` の自己検証が通ること
- `render.py` に素の `: list` が残っていないこと（grep で確認）

## #35 との関係（レビュー指摘を受けて訂正）

初版の本文に「#35 の `render.py` 分が **6 関数ぶん前進する**」と書いたが、**これは誤り**だった。
レビュー指摘を受けて mypy の挙動を実測したところ、`--disallow-untyped-defs` は
**部分注釈の関数も未注釈として弾く**:

```
partial.py:4: error: Function is missing a return type annotation  [no-untyped-def]
partial.py:4: error: Function is missing a type annotation for one or more parameters  [no-untyped-def]
```

つまり本 PR で `blocks` / `line_blocks` / `objects` だけを注釈しても、#35 のカウントは 1 件も減らない。
残りの引数（`tf` / `slide` / `body` / 座標 / `col_ratios` 等）を埋めて初めて 1 関数ぶん進む。

それらは python-pptx の型（`TextFrame` / プレースホルダ / `Length`）を注釈へ持ち込む話で、
**#35 が「方針を最初に決めてから着手する」と切り出した部分そのもの**のため、本 PR には含めない。
本 PR の価値は #35 の進捗ではなく、**IR の契約（何が地の文で何がオブジェクトか）を型で表明し、
実際に誤用を検出できるようにしたこと**にある。

## 影響

- #34 には影響しない
- #35 へは上記の実測結果を申し送る
