### PR TITLE
feat: convert with real PowerPoint on macOS for --pdf

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,8 +61,10 @@ python3 -m md2pptx.parser
 依存: `python-pptx>=1.0` / `PyYAML>=6`（`pyproject.toml` で宣言。インストール時に自動導入）。
 環境は python-pptx 1.0.2 / PyYAML 6 で検証。
 
-CI（`.github/workflows/ci.yml`）は 2 ジョブ。`typecheck` が mypy を 1 回、`generate` が
-**3.11 と 3.14 のマトリクス**で `example.md` の生成まで通す。mypy は `pyproject.toml` の
+CI（`.github/workflows/ci.yml`）は 3 ジョブ。`typecheck` が mypy を 1 回、`generate` が
+**3.11 と 3.14 のマトリクス**で `example.md` の生成まで通し、`pdf` が LibreOffice を入れて
+`--pdf` のページ数まで検証する（runner に PowerPoint は無いので **LibreOffice 経路のみ**。
+macOS の実 PowerPoint 経路は CI では踏めず、手元での確認になる）。mypy は `pyproject.toml` の
 `python_version`（= サポート最古）として解析するので実行処理系は 1 つで足りるが、
 **実行マトリクスは別途必要**。mypy が通ることと実際に動くことは別で、#32 では
 `cli.py` の future import 欠落を実行側だけが捕まえた。
@@ -79,14 +81,18 @@ pdftoppm -png -r 110 -f 3 -l 3 out.pdf /tmp/p # 特定ページを画像化 → 
 magick montage ref.png md.png -tile 2x1 -geometry +4+4 -background '#888' /tmp/cmp.png
 ```
 
-- 見た目の最終確認は **実 PowerPoint** で行う。`--pdf`（後述）の LibreOffice 経路は
-  フォント解決差で崩れるため、当たり確認には使えても最終確認の代替にはならない。
+- 見た目の最終確認は **実 PowerPoint** で行う（macOS なら `--pdf --pdf-converter powerpoint`
+  でも同等）。`--pdf` の LibreOffice 経路はフォント解決差で崩れるため、当たり確認には
+  使えても最終確認の代替にはならない。
 - 実 PowerPoint 変換に使う手元のツールは、出力先を指定できて入力の場所にも制約が無いものを想定。
 - 構造の確認（枚数・プレースホルダ・フォントサイズ等）は python-pptx で読む。
 
 `md2pptx` 自身にも `--pdf` がある（Issue #39）。生成後に PDF を作る土台機能で、既定 `auto` は
-native PowerPoint → LibreOffice の順に試す。`--pdf-converter` に実 PowerPoint 変換ツールを
-指定して使うこともできる。忠実度は保証しない（README 参照）。
+native PowerPoint → LibreOffice の順に試す。**macOS では PowerPoint.app があれば `auto` が
+osascript 経由で実 PowerPoint を使う**ので、`md2pptx … --pdf --pdf-converter powerpoint` の
+出力はそのまま最終確認に使える（LibreOffice 経路は当たり確認どまり）。初回は TCC 承認が要り、
+承認は呼び出し元アプリごとに別管理（README 参照）。`--pdf-converter` に外部の実 PowerPoint
+変換ツールを指定することもできる。忠実度は保証しない（README 参照）。
 
 ## 規約・設計上の約束
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -655,10 +655,18 @@ md2pptx input.md --theme OfficeTheme.pptx -o out.pptx
 - `--keep-base PATH`：ステージ 0 で作った base pptx を破棄せず保存（デバッグ用）。
 - `--pdf [PATH]`：pptx 生成後に PDF も作る（プレビュー用）。PATH 省略時は出力 pptx と同じ
   場所・basename の `.pdf`。変換は `pdf.py` が担う。**PDF 変換だけ失敗しても終了コードは 0**
-  （警告のみ）——編集しながらのプレビューを止めないため。忠実度は保証しない（README 参照）。
+  （警告のみ）——編集しながらのプレビューを止めないため。忠実度は変換器による（README 参照）。
 - `--pdf-converter NAME|COMMAND`：PDF 変換器。`auto`（既定・PowerPoint→LibreOffice）/
   `powerpoint` / `libreoffice` / 任意コマンド（`{input}`/`{output}`/`{outdir}` 置換）。
   環境変数 `MD2PPTX_PDF_CONVERTER` を上書き。
+  - macOS の `powerpoint` は `osascript`（`save … in (POSIX file p) as save as PDF`）で
+    実 PowerPoint に変換させる。`POSIX file` への coerce は必須（POSIX パス文字列だと
+    保存先を解決できない）。TCC 承認（オートメーション＋ファイルアクセス）は**呼び出し元
+    バイナリごと**に別管理で、未承認だと承認待ちで止まる（README の注意参照）。
+  - `save as PDF` は印刷パイプライン経由で**無音失敗しうる**（exit 0 でも PDF が無い・空）。
+    そのため終了コードを信じず、変換前に既存出力を消したうえで**成果物の存在＋非空**を
+    成功条件にする。既存出力の削除は `convert()` で全バックエンド共通に行う——残したままだと
+    前回の PDF がこの条件を満たし、失敗を成功と誤判定するため。
 - `--version`：バージョンを表示して終了（`md2pptx.__version__` が単一の情報源）。
 - 終了時に `saved: <out> slides: <n>`（`--pdf` 時はさらに `saved: <pdf>`）を出力。
 - thmx 変換・パースのエラーは「原因＋（パース時は行番号）」を表示して失敗させる。

--- a/README.md
+++ b/README.md
@@ -88,10 +88,13 @@ md2pptx slide.md --theme theme.pptx -o slide.pptx --pdf out.pdf  # 出力先を�
 
 - 変換器は `--pdf-converter` か環境変数 `MD2PPTX_PDF_CONVERTER` で選べます（CLI 引数が優先）。
   既定の `auto` は **native PowerPoint → LibreOffice** の順に、使えるものを試します。
-  ただし **macOS の native PowerPoint は非対応**です（AppleScript にヘッドレスで PDF を
-  書き出す確実な手段が無く、保存ダイアログでハングするため）。macOS では `auto` は
-  LibreOffice を使います。macOS で PowerPoint の忠実な出力が欲しい場合は、実 PowerPoint を
-  叩く外部ツールを `--pdf-converter 'yourtool -o {output} {input}'` のように指定してください。
+  macOS では PowerPoint.app があれば AppleScript（`osascript`）経由で実 PowerPoint に
+  変換させ、未インストールや失敗時に LibreOffice へフォールバックします。
+- **macOS では初回に TCC（プライバシーとセキュリティ）の承認が必要**です。PowerPoint を
+  操作する許可（オートメーション）とファイルアクセスのダイアログが出るので、GUI セッション
+  で一度許可してください。承認は**呼び出し元アプリごと**（Terminal / iTerm / VS Code など）
+  に別管理なので、実行元を変えると再度承認が要ります。ダイアログを出せない実行環境
+  （launchd / cron など）では、未承認だと応答待ちのまま止まって見えます。
 - 任意のツールも指定できます。プレースホルダ `{input}` / `{output}` / `{outdir}` を置換します
   （1 つも無ければ末尾に `{input}` を補い、ツールが入力の隣に書いた `.pdf` を目的地へ移します）。
 
@@ -100,10 +103,13 @@ md2pptx slide.md --theme theme.pptx -o slide.pptx --pdf out.pdf  # 出力先を�
   ```
 
 - **PDF 変換だけ失敗しても pptx は保存済みとして終了コードは 0**（警告を stderr に出すのみ）。
-  編集しながらのプレビュー運用を変換失敗で止めないためです。
-- **忠実度は保証しません。** とくに LibreOffice の出力はテーマフォントの解決差などで
-  実 PowerPoint と一致しません（太字寄りになる・行送りが詰まる等）。PDF プレビューは
-  **編集中の当たり確認**用で、見た目の最終確認は実 PowerPoint で行ってください。
+  編集しながらのプレビュー運用を変換失敗で止めないためです。ただし**変換前に既存の PDF は
+  消します**（失敗すると PDF は無くなります）。古い PDF が残っていると、それを新しい出力と
+  取り違えて見続けることになるためです。
+- **忠実度は変換器によります。** LibreOffice の出力はテーマフォントの解決差などで実 PowerPoint
+  と一致しません（太字寄りになる・行送りが詰まる等）ので、**編集中の当たり確認**用と考えて
+  ください。PowerPoint 経路（macOS / Windows）は実 PowerPoint 自身の出力なので、そのまま
+  見た目の確認に使えます。どちらを使ったかは PDF の Producer（`pdfinfo` 等）で分かります。
 
 ### 試す
 

--- a/md2pptx/cli.py
+++ b/md2pptx/cli.py
@@ -97,8 +97,9 @@ def _parse_args(argv):
     )
     ap.add_argument(
         "--pdf", nargs="?", const=True, default=None, metavar="PATH",
-        help="also render a PDF after the pptx (preview only, not a faithful "
-             "PowerPoint render); PATH defaults to the output with a .pdf suffix",
+        help="also render a PDF after the pptx (fidelity depends on the "
+             "converter: LibreOffice is a preview, PowerPoint is the real "
+             "render); PATH defaults to the output with a .pdf suffix",
     )
     ap.add_argument(
         "--pdf-converter", metavar="NAME|COMMAND",

--- a/md2pptx/pdf.py
+++ b/md2pptx/pdf.py
@@ -3,9 +3,9 @@
 """pptx → PDF 変換（生成後プレビュー用の土台．DESIGN.md §7 / Issue #39）．
 
 「Markdown を編集しながら PDF を見る」運用の基礎として，生成した pptx を
-そのまま PDF にする．**忠実度は保証しない**：LibreOffice の出力はテーマ
-フォントの解決差などで実 PowerPoint と一致しない（README 参照）。見た目の
-最終確認は実 PowerPoint で行う前提は変えない．
+そのまま PDF にする．**忠実度は変換器による**：LibreOffice の出力はテーマ
+フォントの解決差などで実 PowerPoint と一致しない（当たり確認どまり）が，
+PowerPoint 経路は実 PowerPoint 自身の出力なので見た目の確認に使える（README 参照）．
 
 変換器は 3 系統:
 
@@ -16,12 +16,14 @@
   無ければ末尾に ``{input}`` を補う（出力パスを取らないツール向け）．その場合
   ツールは入力の隣に ``<basename>.pdf`` を書く想定で，期待パスと違えば移動する．
 
-**macOS の native PowerPoint は非対応**：この PowerPoint ビルドの AppleScript 辞書には
-``export`` コマンドが無く，標準 ``save … as save as PDF`` は宛先型により無反応または保存
-ダイアログでハングする（実測）。ハングは実害なので試みず明示エラーにし，``auto`` は
-LibreOffice へフォールバックする．実 PowerPoint 相当の忠実な変換が要る場合は，実 PowerPoint
-を叩く外部変換ツールを ``--pdf-converter`` に指定する．Windows の PowerPoint は
-COM（``SaveAs`` format 32）で対応．
+**macOS の native PowerPoint 対応**：AppleScript 辞書に ``export`` コマンドは無いが，
+``save … in (POSIX file p) as save as PDF`` は POSIX file への coerce により安定して動作
+する（PowerPoint 16.111.1 で 14 ページの変換を実測）。以前「無反応／保存ダイアログでハング」
+と観測したのは，オートメーション／powerbox の TCC 承認が未取得でダイアログの応答待ちに
+なっていたためで，承認済みなら問題なく変換できる（TCC 承認は実行元バイナリごとに別管理な
+ので，iTerm・VS Code・launchd から呼ぶならそれぞれで承認が要る）。``auto`` は macOS で
+PowerPoint.app があれば実 PowerPoint を優先し，無い／失敗した場合は LibreOffice へフォール
+バックする．Windows の PowerPoint は COM（``SaveAs`` format 32）で対応．
 
 このモジュールは cli 以外に依存しない（python-pptx 非依存）．外部プロセスの
 起動と，どのバイナリを使うかの解決だけを担う．
@@ -45,6 +47,23 @@ class PdfError(Exception):
 ENV_CONVERTER = "MD2PPTX_PDF_CONVERTER"
 
 
+# macOS の実 PowerPoint で pptx → PDF にする AppleScript．osascript に stdin で渡し，
+# 入出力パスは argv で渡す（パスを文字列リテラルに埋め込まないので，スペースや引用符を
+# 含むパスでも構文が壊れない）．``POSIX file`` への coerce は Sonoma 以降の alias 問題の
+# 回避に必須（素の POSIX パス文字列では保存先を解決できない）．
+_APPLESCRIPT_PPTX_TO_PDF = '''on run argv
+    set inPath to item 1 of argv
+    set outPath to item 2 of argv
+    tell application "Microsoft PowerPoint"
+        activate
+        open (POSIX file inPath)
+        set theDoc to active presentation
+        save theDoc in (POSIX file outPath) as save as PDF
+        close theDoc saving no
+    end tell
+end run'''
+
+
 def _which_libreoffice() -> str | None:
     """LibreOffice の実行ファイルを探す．PATH 優先，無ければ OS 既知の場所．"""
     for name in ("soffice", "libreoffice"):
@@ -66,14 +85,20 @@ def _which_libreoffice() -> str | None:
     return None
 
 
-def _run(cmd: list[str], what: str) -> None:
+def _macos_powerpoint_installed() -> bool:
+    """macOS に Microsoft PowerPoint が入っているか（app バンドルの有無で判定）．"""
+    return os.path.isdir("/Applications/Microsoft PowerPoint.app")
+
+
+def _run(cmd: list[str], what: str, input: str | None = None) -> None:
     """外部コマンドを実行し，失敗を PdfError に変換する．
 
     成功時の出力は捨てる．失敗時のみ stderr（無ければ stdout）の末尾 1 行を
-    原因として拾う（cli が警告に整形する）．
+    原因として拾う（cli が警告に整形する）．input を渡すと stdin に流す
+    （osascript にスクリプト本体を与えるのに使う）．
     """
     try:
-        proc = subprocess.run(cmd, capture_output=True, text=True)
+        proc = subprocess.run(cmd, capture_output=True, text=True, input=input)
     except FileNotFoundError:
         raise PdfError(f"{what}: command not found: {cmd[0]}")
     if proc.returncode != 0:
@@ -113,17 +138,13 @@ def _convert_powerpoint(src: str, dst: str) -> None:
     src_abs = os.path.abspath(src)
     dst_abs = os.path.abspath(dst)
     if sys.platform == "darwin":
-        # macOS の PowerPoint（AppleScript）は無人 PDF 化が不安定．sdef に `export`
-        # コマンドは無く，標準 `save … in <file> as save as PDF` は宛先の型次第で
-        # 無反応（POSIX パス文字列）か保存ダイアログでハング（POSIX file）になる
-        # （このビルドで実測）．ハングは実害なので試みず，明示エラーにして呼び出し側に
-        # 委ねる：`auto` は LibreOffice へフォールバックし，実 PowerPoint 相当の忠実な
-        # 変換が要る場合は実 PowerPoint を叩く外部ツールを --pdf-converter に指定する．
-        raise PdfError(
-            "native PowerPoint on macOS is not supported for headless PDF "
-            "(no reliable AppleScript path on this build); use LibreOffice, or "
-            "point --pdf-converter at an external converter")
-    if sys.platform.startswith("win"):
+        # macOS は osascript 経由で実 PowerPoint を叩く．
+        # スクリプト本体は stdin で，入出力パスは argv で渡す．TCC 承認（オート
+        # メーション＋ファイルアクセス）が済んでいれば安定して変換できる（未承認だと承認
+        # ダイアログの応答待ちでハングしたように見えるので注意）．
+        _run(["osascript", "-", src_abs, dst_abs], "powerpoint",
+             input=_APPLESCRIPT_PPTX_TO_PDF)
+    elif sys.platform.startswith("win"):
         # PowerShell + COM．32 = ppSaveAsPDF．パスは単一引用符文字列に埋めるので，
         # パス内の ' は '' にエスケープする（O'Brien 等でコマンドが壊れるのを防ぐ）．
         src_ps = src_abs.replace("'", "''")
@@ -141,8 +162,10 @@ def _convert_powerpoint(src: str, dst: str) -> None:
         _run(["powershell", "-NoProfile", "-Command", ps], "powerpoint")
     else:
         raise PdfError("native PowerPoint is only available on macOS or Windows")
-    if not os.path.isfile(dst_abs):
-        raise PdfError("powerpoint did not produce a PDF")
+    # osascript/COM はいずれも無音失敗（exit 0 でも PDF が無い/空）がありうるので，
+    # 終了コードだけでなく成果物の存在と非空を成功条件にする．
+    if not os.path.isfile(dst_abs) or os.path.getsize(dst_abs) == 0:
+        raise PdfError("powerpoint did not produce a (non-empty) PDF")
 
 
 def _convert_custom(command: str, src: str, dst: str) -> None:
@@ -225,13 +248,26 @@ def convert(src: str, dst: str, converter: str | None) -> None:
     if not os.path.isdir(dst_dir):
         raise PdfError(f"output directory does not exist: {dst_dir}")
 
+    # 既存の出力は変換前に消す．残したままだと，変換が実際には失敗しても前回の PDF が
+    # 「存在かつ非空」の成功条件を満たしてしまい，古い内容を見続けることになる
+    # （macOS の save as PDF は無音失敗しうる）．
+    try:
+        os.remove(dst)
+    except FileNotFoundError:
+        pass
+    except OSError as e:
+        raise PdfError(f"cannot replace existing PDF: {dst} ({e})")
+
     name = (converter or "auto").strip()
 
     if name == "auto":
-        # native PowerPoint → LibreOffice の順に試す．native PowerPoint を試すのは
-        # Windows のみ（macOS の PowerPoint は非対応で必ず失敗するため試さない）．
+        # 実 PowerPoint（テーマ忠実度が高い）→ LibreOffice の順に試す．PowerPoint を試すのは
+        # Windows，または macOS で PowerPoint.app がインストールされている場合．未インストール
+        # や変換失敗時は LibreOffice へフォールバックする．
         errors: list[str] = []
-        if sys.platform.startswith("win"):
+        try_powerpoint = sys.platform.startswith("win") or (
+            sys.platform == "darwin" and _macos_powerpoint_installed())
+        if try_powerpoint:
             try:
                 _convert_powerpoint(src, dst)
                 return


### PR DESCRIPTION
## 概要

#40 は「macOS の native PowerPoint は非対応」として `auto` を LibreOffice へ落としていた。理由は「AppleScript 辞書に `export` が無く、`save as PDF` は無反応かハングする」だったが、**その症状は API ではなく TCC 承認が原因**だった。オートメーションとファイルアクセスを承認した状態なら `save theDoc in (POSIX file p) as save as PDF` は安定して変換できる（PowerPoint 16.111.1 で 14 スライド → 14 ページを実測）。

これにより、**PowerPoint がインストールされた macOS** では既定の `--pdf` がそのまま実 PowerPoint の出力になる。未インストールなら従来どおり LibreOffice へフォールバックするので、そこは変わらない。LibreOffice はテーマの細字フォントを解決できず全体が太字寄りになるため、macOS の既定経路にはこれまで忠実な選択肢が無かった。

関連: Refs #39（Issue は #40 で close 済みのため follow-up）

## 変更内容

### macOS の実 PowerPoint 経路（`md2pptx/pdf.py`）

- `_convert_powerpoint` の darwin 分岐で `osascript` を起動。スクリプト本体は stdin、入出力パスは argv で渡すので、スペースや引用符を含むパスで構文が壊れない
- `POSIX file` への coerce は必須（素の POSIX パス文字列では保存先を解決できない）
- `auto` は `/Applications/Microsoft PowerPoint.app` があれば実 PowerPoint を優先し、未インストール／失敗なら LibreOffice へフォールバック

### 無音失敗の検知を成立させる（バグ修正）

`save as PDF` は印刷パイプライン経由で exit 0 のまま失敗しうるため、成功条件は終了コードではなく**成果物の存在＋非空**にしている。ただしこの判定は**前回の PDF が残っていると成立しない**——古い成果物が条件を満たしてしまい、変換が失敗しても成功と報告され、ユーザは古い内容を見続ける。`convert()` で変換前に既存の出力先を削除するようにした（全バックエンド共通）。

### ドキュメント

- 忠実度の説明を「保証しない」から**変換器次第**へ（`--pdf` の help / README / DESIGN.md / `pdf.py`）。LibreOffice は当たり確認、PowerPoint 経路は実 PowerPoint 自身の出力
- **TCC 承認は呼び出し元バイナリごと**に別管理であることを README に明記（iTerm の承認は VS Code に引き継がれない。launchd / cron はダイアログを出せないので待ちになる）
- CLAUDE.md: CI が LibreOffice 経路しか踏めない旨を追記（ついでに「2 ジョブ」の古い記述を 3 ジョブへ修正）

## 検証

| 経路 | ページ数 | PDF Producer |
|---|---|---|
| `--pdf-converter powerpoint` | 14（= スライド数） | Quartz PDFContext（実 PowerPoint） |
| `--pdf-converter auto` | 14 | Quartz PDFContext（LibreOffice に落ちていない） |
| `--pdf-converter libreoffice` | 14 | LibreOffice 26.2.4.2 |

LibreOffice も導入済みの環境なので、`auto` の Producer が Quartz であることが「実 PowerPoint を優先した」直接の裏取りになる。3 ページ目を画像化して目視でもテーマの色・フォントを確認済み。

既存出力の削除は、意図的に失敗する変換器（`--pdf-converter 'false {input} {output}'`）を既存 PDF がある状態で実行し、警告が出て PDF が残らないことを確認した。

mypy（キャッシュ削除 + `--no-incremental`）clean。CI の `pdf` ジョブは LibreOffice 名指しなので今回の変更の影響を受けない。
