### PR TITLE
feat!: split --pdf into a flag plus --pdf-output PATH

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
           python-version: "3.14"
       - run: sudo apt-get update && sudo apt-get install -y libreoffice-impress poppler-utils
       - run: pip install -e .
-      - run: md2pptx example.md --theme OfficeTheme.pptx -o out.pptx --pdf out.pdf --pdf-converter libreoffice
+      - run: md2pptx example.md --theme OfficeTheme.pptx -o out.pptx --pdf-output out.pdf --pdf-converter libreoffice
       - name: Check the PDF was produced with the expected page count
         run: |
           test -f out.pdf

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -653,9 +653,17 @@ md2pptx input.md --theme OfficeTheme.pptx -o out.pptx
 - `--theme`：テーマファイル。**`.thmx` / `.pptx` 両対応**（拡張子で自動分岐。§3.5）。フロントマター `theme:` を上書き。
 - `-o/--output`：出力 pptx。フロントマター `output:` を上書き。
 - `--keep-base PATH`：ステージ 0 で作った base pptx を破棄せず保存（デバッグ用）。
-- `--pdf [PATH]`：pptx 生成後に PDF も作る（プレビュー用）。PATH 省略時は出力 pptx と同じ
-  場所・basename の `.pdf`。変換は `pdf.py` が担う。**PDF 変換だけ失敗しても終了コードは 0**
-  （警告のみ）——編集しながらのプレビューを止めないため。忠実度は変換器による（README 参照）。
+- `--pdf`：pptx 生成後に PDF も作る（値は取らない）。出力先は出力 pptx と同じ場所・basename の
+  `.pdf`。変換は `pdf.py` が担う。**PDF 変換だけ失敗しても終了コードは 0**（警告のみ）——編集
+  しながらのプレビューを止めないため。忠実度は変換器による（README 参照）。
+- `--pdf-output PATH`：PDF の出力先。**単独で指定しても生成を有効にする**（`--keep-base PATH` と
+  同じ形。出力先を書いた人が「作るな」を意図することはない）。`--pdf` と併用しても矛盾ではない
+  ので、その場合は PATH に作る。
+  - `--pdf` に値を持たせる形（`nargs="?"`）は採らない。`md2pptx --pdf deck.md` で入力ファイルが
+    `--pdf` の値として食われ、「input が無い」という原因の分からないエラーになるため（#42）。
+  - 有効化するのは**成果物を名指しするオプションだけ**。`--pdf-converter` は「どう作るか」の
+    指定なので有効化しない——`MD2PPTX_PDF_CONVERTER` を export しただけで全実行が PDF を
+    作り始めてしまう。
 - `--pdf-converter NAME|COMMAND`：PDF 変換器。`auto`（既定・PowerPoint→LibreOffice）/
   `powerpoint` / `libreoffice` / 任意コマンド（`{input}`/`{output}`/`{outdir}` 置換）。
   環境変数 `MD2PPTX_PDF_CONVERTER` を上書き。

--- a/README.md
+++ b/README.md
@@ -69,7 +69,8 @@ python3 -m md2pptx input.md
 | `--theme PATH` | テーマファイル（`.thmx` / `.pptx` 両対応）。フロントマター `theme:` を上書き |
 | `-o, --output PATH` | 出力 pptx。フロントマター `output:` を上書き |
 | `--keep-base PATH` | `.thmx` から作る中間 base pptx を破棄せず保存（デバッグ用） |
-| `--pdf [PATH]` | pptx 生成後に PDF も作る。PATH 省略時は出力 pptx と同じ場所・同じ basename の `.pdf` |
+| `--pdf` | pptx 生成後に PDF も作る。出力先は出力 pptx と同じ場所・同じ basename の `.pdf` |
+| `--pdf-output PATH` | PDF の出力先を指定する。単独で指定しても PDF を作る（`--pdf` は不要） |
 | `--pdf-converter NAME\|COMMAND` | PDF 変換器。`auto`（既定）/ `powerpoint` / `libreoffice` / 任意のコマンド行。環境変数 `MD2PPTX_PDF_CONVERTER` を上書き |
 | `--version` | バージョンを表示して終了（入力ファイルは不要） |
 
@@ -82,9 +83,15 @@ python3 -m md2pptx input.md
 結果を確認する、という使い方の土台です。
 
 ```bash
-md2pptx slide.md --theme theme.pptx -o slide.pptx --pdf          # slide.pdf も作る
-md2pptx slide.md --theme theme.pptx -o slide.pptx --pdf out.pdf  # 出力先を指定
+md2pptx slide.md --theme theme.pptx -o slide.pptx --pdf              # slide.pdf も作る
+md2pptx slide.md --theme theme.pptx --pdf-output out.pdf             # 出力先を指定（--pdf は不要）
 ```
+
+- **`--pdf-output` を指定すれば `--pdf` は要りません**（出力先を書いた時点で「作る」意思は明らか
+  なので、`--keep-base PATH` と同じく指定すること自体が有効化になります）。両方指定した場合は
+  `--pdf-output` のパスに作ります。逆に **`--pdf-converter` は PDF 生成を有効にしません**——
+  あれは「どう作るか」の指定で、`MD2PPTX_PDF_CONVERTER` を export しているだけで毎回 PDF が
+  作られては困るからです。
 
 - 変換器は `--pdf-converter` か環境変数 `MD2PPTX_PDF_CONVERTER` で選べます（CLI 引数が優先）。
   既定の `auto` は **native PowerPoint → LibreOffice** の順に、使えるものを試します。

--- a/md2pptx/cli.py
+++ b/md2pptx/cli.py
@@ -95,11 +95,18 @@ def _parse_args(argv):
         "--keep-base", metavar="PATH",
         help="keep the intermediate base pptx (from .thmx) at PATH",
     )
+    # --pdf は値を取らない．値を省略できるオプション（nargs="?"）にすると
+    # `md2pptx --pdf deck.md` で入力ファイルが --pdf の値として食われ，「input が無い」
+    # という原因の分からないエラーになる（Issue #42）．出力先は --pdf-output で取る．
     ap.add_argument(
-        "--pdf", nargs="?", const=True, default=None, metavar="PATH",
-        help="also render a PDF after the pptx (fidelity depends on the "
-             "converter: LibreOffice is a preview, PowerPoint is the real "
-             "render); PATH defaults to the output with a .pdf suffix",
+        "--pdf", action="store_true",
+        help="also render a PDF after the pptx, next to the output pptx "
+             "(fidelity depends on the converter: LibreOffice is a preview, "
+             "PowerPoint is the real render)",
+    )
+    ap.add_argument(
+        "--pdf-output", metavar="PATH",
+        help="render the PDF to PATH; implies --pdf",
     )
     ap.add_argument(
         "--pdf-converter", metavar="NAME|COMMAND",
@@ -173,9 +180,12 @@ def _run(args):
 
     # 4) 任意: PDF も生成（プレビュー用）．失敗しても pptx は成功なので終了コードは
     # 変えない——編集しながらのプレビュー運用を変換失敗で止めないため（Issue #39）．
-    if args.pdf is not None:
-        pdf_out = args.pdf if isinstance(args.pdf, str) \
-            else pdf_backend.default_pdf_path(output)
+    # --pdf-output は単体で生成を有効にする（出力先を書いた人が「作るな」を意図する
+    # ことはない）．--pdf-converter は「どう作るか」の指定なので有効化しない——
+    # 環境変数 MD2PPTX_PDF_CONVERTER を export しただけで全実行が PDF を作り始めて
+    # しまうため（Issue #42）．
+    if args.pdf or args.pdf_output:
+        pdf_out = args.pdf_output or pdf_backend.default_pdf_path(output)
         converter = args.pdf_converter or os.environ.get(ENV_CONVERTER)
         # 変換は数秒かかる（LibreOffice は例で ~4 秒）．無音で止まって見えないよう
         # 開始を stderr に出す（stdout の saved: 行は汚さない）．

--- a/md2pptx/cli.py
+++ b/md2pptx/cli.py
@@ -136,6 +136,11 @@ def main(argv=None):
 def _run(args):
     if not os.path.isfile(args.input):
         raise SystemExit(f"md2pptx: input not found: {args.input}")
+    # 空の --pdf-output は「指定なし」と区別が付かないまま黙って PDF 生成を落とす
+    # （`--pdf-output "$PDF_OUT"` で変数が未設定のときに起こる）．黙って何もしないより，
+    # ここで落とす．pptx を書く前に検査するので、失敗しても成果物が中途半端に残らない．
+    if args.pdf_output is not None and not args.pdf_output.strip():
+        raise SystemExit("md2pptx: --pdf-output requires a path")
 
     # 1) Markdown -> IR（Deck）
     try:


### PR DESCRIPTION
## 概要

`--pdf` が値を省略できる形（`nargs="?"`）だったため、オプションを入力ファイルより先に書くと argparse が入力ファイルを `--pdf` の PATH として食べてしまい、渡しているはずの input について「無い」と言われていた。

```
% md2pptx --pdf toshi-iot74/iot74-slide.md
md2pptx: error: the following arguments are required: input
```

`--pdf` を値なしフラグにし、出力先を `--pdf-output PATH` に分離することで、引数の順序に依存しない解釈になる。

Resolves #42

## 変更内容

### `md2pptx/cli.py`

- `--pdf` を `action="store_true"` に変更（値を取らない）
- `--pdf-output PATH` を新設。**単独指定で PDF 生成を有効化する**
- 生成判定は `if args.pdf or args.pdf_output`、パスは `--pdf-output` 優先、無ければ `default_pdf_path(output)`

| 指定 | 挙動 |
|---|---|
| `--pdf` のみ | 出力 pptx と同じ場所・basename の `.pdf` |
| `--pdf-output x.pdf` のみ | `x.pdf` に作る（暗黙に有効化） |
| 両方 | `x.pdf` に作る（矛盾ではないのでエラーにしない） |
| どちらも無し | 作らない |

`--pdf-output` を単独で有効化する理由は、出力先を書いた人が「でも作るな」を意図することはないから。既存の `--keep-base PATH` も同じ形（対になる `--keep` は無い）。

**`--pdf-converter` は有効化しない。** あれは「どう作るか」の指定で、`MD2PPTX_PDF_CONVERTER` として環境変数に常時 export されうる。有効化を意味させると export しただけで全実行が PDF を作り始めてしまう。**成果物を名指しするオプションは有効化する、方法を設定するオプションはしない**、という線を引いた。

### CI

`ci.yml` の pdf ジョブが旧記法 `--pdf out.pdf` を使っていたので `--pdf-output out.pdf` へ更新（そのままなら CI が落ちる変更）。

### ドキュメント

README のオプション表・使用例・注記、DESIGN.md §7 を新しい形に更新。`nargs="?"` を採らない理由も §7 に残した。

## 検証

Issue の検証項目 5 件をすべて実行（`MD2PPTX_PDF_CONVERTER` が export された状態も含む）:

| 検証 | 結果 |
|---|---|
| `md2pptx --pdf example.md …`（本件の再現ケース） | 通る。既定パスに PDF 生成 |
| `--pdf-output named.pdf` のみ（`--pdf` 無し） | `named.pdf` を生成 |
| `--pdf` と `--pdf-output both.pdf` 併用 | `both.pdf` のみ生成（既定パスには作らない） |
| `--pdf-converter powerpoint` だけ / 環境変数だけ | PDF を作らない |
| どちらも無い既存の呼び出し | 14 スライドの pptx のみ。変化なし |

加えて CI と同じ形（`--pdf-output out.pdf --pdf-converter libreoffice`）を手元で実行し、14 ページ・Producer = LibreOffice を確認。旧記法 `--pdf out.pdf` は `error: unrecognized arguments` で明示的に落ちることも確認した（分かりにくい「input が無い」ではなくなる）。

mypy（キャッシュ削除 + `--no-incremental`）clean。

## 破壊的変更

`--pdf PATH` は使えなくなる（`--pdf-output PATH` に置き換え）。#42 のとおり、この形式の既存の呼び出しは存在しないため移行措置は設けていない。
