### PR TITLE
fix: let auto pick a converter, not substitute one that failed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,7 +88,8 @@ magick montage ref.png md.png -tile 2x1 -geometry +4+4 -background '#888' /tmp/c
 - 構造の確認（枚数・プレースホルダ・フォントサイズ等）は python-pptx で読む。
 
 `md2pptx` 自身にも `--pdf` がある（Issue #39）。生成後に PDF を作る土台機能で、既定 `auto` は
-native PowerPoint → LibreOffice の順に試す。**macOS では PowerPoint.app があれば `auto` が
+native PowerPoint → LibreOffice の順に**使えるものを選ぶ**（無い物は飛ばすが、**在る物の失敗は
+握らない**——Issue #46。落とすと忠実度の違う PDF を黙って掴むことになる）。**macOS では PowerPoint.app があれば `auto` が
 osascript 経由で実 PowerPoint を使う**ので、`md2pptx … --pdf --pdf-converter powerpoint` の
 出力はそのまま最終確認に使える（LibreOffice 経路は当たり確認どまり）。初回はオートメーションの
 TCC 承認が要る（呼び出し元アプリごとに別管理・README 参照）。`--pdf-converter` に外部の実

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -667,6 +667,13 @@ md2pptx input.md --theme OfficeTheme.pptx -o out.pptx
 - `--pdf-converter NAME|COMMAND`：PDF 変換器。`auto`（既定・PowerPoint→LibreOffice）/
   `powerpoint` / `libreoffice` / 任意コマンド（`{input}`/`{output}`/`{outdir}` 置換）。
   環境変数 `MD2PPTX_PDF_CONVERTER` を上書き。
+  - `auto` がするのは**探索だけ**で、失敗の肩代わりはしない（#46）。「その変換器が無い」
+    （`_Unavailable`）ときだけ次へ進み、**在る物が失敗したらそのまま失敗**させて
+    `--pdf-converter libreoffice` を案内する。落としてしまうと忠実度という成果物の性質が
+    黙って入れ替わるうえ、隠れる原因（オートメーション承認の拒否・ライセンス未認証など）は
+    利用者が直せるものだから。可用性の判定は macOS が app バンドルの有無、Windows は
+    COM オブジェクトを作れたか（PowerShell に成功マーカーを出させて切り分ける）、
+    LibreOffice は `soffice` が見つかるか。
   - macOS の `powerpoint` は `osascript`（`save … in (POSIX file p) as save as PDF`）で
     実 PowerPoint に変換させる。`POSIX file` への coerce は必須（POSIX パス文字列だと
     保存先を解決できない）。オートメーションの TCC 承認は**呼び出し元バイナリごと**に

--- a/README.md
+++ b/README.md
@@ -87,9 +87,7 @@ md2pptx slide.md --pdf
 md2pptx slide.md --pdf-output preview.pdf  # PDF の名前や場所を変える（--pdf は不要）
 ```
 
-- 既定の `auto` は**実 PowerPoint → LibreOffice** の順に、使えるものを選びます。LibreOffice で
-  変換した PDF は実 PowerPoint と一致しない（太字寄りになる・行送りが詰まる）ので、
-  **編集中の当たり確認**までと考えてください。
+- 既定の `auto` は**実 PowerPoint → LibreOffice** の順に、使えるものを選びます。
 - `--pdf` と `--pdf-output` を両方指定したときは `--pdf-output` のパスに作ります。置き先の
   ディレクトリは**あらかじめ用意しておいてください**（タイポで勝手にディレクトリを作らない
   ため、無ければ PDF は作りません）。**`--pdf-converter` だけでは PDF は作られません**——

--- a/README.md
+++ b/README.md
@@ -87,10 +87,11 @@ md2pptx slide.md --pdf
 md2pptx slide.md --pdf-output preview.pdf  # PDF の名前や場所を変える（--pdf は不要）
 ```
 
-- 既定の `auto` は**実 PowerPoint → LibreOffice** の順に、使えるものを試します。LibreOffice で
-  変換した PDF は実 PowerPoint と一致しない（太字寄りになる・行送りが詰まる）ので、
-  **編集中の当たり確認**までと考えてください。どちらが使われたかは PDF の Producer
-  （`pdfinfo` 等）で分かります。
+- 既定の `auto` は**実 PowerPoint → LibreOffice** の順に、使えるものを選びます。PowerPoint が
+  ある環境では必ずそれを使い、**変換に失敗しても LibreOffice には切り替えません**（理由を表示
+  して終わります）。組版の違う PDF を黙って掴ませないためです。LibreOffice で変換した PDF は
+  実 PowerPoint と一致しない（太字寄りになる・行送りが詰まる）ので、**編集中の当たり確認**まで
+  と考えてください。
 - `--pdf` と `--pdf-output` を両方指定したときは `--pdf-output` のパスに作ります。置き先の
   ディレクトリは**あらかじめ用意しておいてください**（タイポで勝手にディレクトリを作らない
   ため、無ければ PDF は作りません）。**`--pdf-converter` だけでは PDF は作られません**——

--- a/README.md
+++ b/README.md
@@ -87,11 +87,9 @@ md2pptx slide.md --pdf
 md2pptx slide.md --pdf-output preview.pdf  # PDF の名前や場所を変える（--pdf は不要）
 ```
 
-- 既定の `auto` は**実 PowerPoint → LibreOffice** の順に、使えるものを選びます。PowerPoint が
-  ある環境では必ずそれを使い、**変換に失敗しても LibreOffice には切り替えません**（理由を表示
-  して終わります）。組版の違う PDF を黙って掴ませないためです。LibreOffice で変換した PDF は
-  実 PowerPoint と一致しない（太字寄りになる・行送りが詰まる）ので、**編集中の当たり確認**まで
-  と考えてください。
+- 既定の `auto` は**実 PowerPoint → LibreOffice** の順に、使えるものを選びます。LibreOffice で
+  変換した PDF は実 PowerPoint と一致しない（太字寄りになる・行送りが詰まる）ので、
+  **編集中の当たり確認**までと考えてください。
 - `--pdf` と `--pdf-output` を両方指定したときは `--pdf-output` のパスに作ります。置き先の
   ディレクトリは**あらかじめ用意しておいてください**（タイポで勝手にディレクトリを作らない
   ため、無ければ PDF は作りません）。**`--pdf-converter` だけでは PDF は作られません**——

--- a/md2pptx/pdf.py
+++ b/md2pptx/pdf.py
@@ -118,8 +118,23 @@ def _which_libreoffice() -> str | None:
 
 
 def _macos_powerpoint_installed() -> bool:
-    """macOS に Microsoft PowerPoint が入っているか（app バンドルの有無で判定）．"""
-    return os.path.isdir("/Applications/Microsoft PowerPoint.app")
+    """macOS に Microsoft PowerPoint が入っているか．
+
+    既定の場所にあれば即座に真（ほとんどはこれで済む）．無ければ LaunchServices に
+    **名前で**問い合わせる．変換本体（``open -a`` と ``tell application``）も名前で
+    解決するので，置き場所を変えている環境で**ここだけがパスで否定する**と，動くはずの
+    PowerPoint を使わずに LibreOffice へ落ちる（＝#46 で消した無言の切り替えが戻る）．
+    この問い合わせはアプリを起動しない（実測 46ms）．
+    """
+    if os.path.isdir("/Applications/Microsoft PowerPoint.app"):
+        return True
+    try:
+        proc = subprocess.run(
+            ["osascript", "-e", 'id of app "Microsoft PowerPoint"'],
+            capture_output=True, text=True)
+    except OSError:
+        return False
+    return proc.returncode == 0
 
 
 def _macos_prelaunch_powerpoint_hidden() -> None:

--- a/md2pptx/pdf.py
+++ b/md2pptx/pdf.py
@@ -9,7 +9,8 @@ PowerPoint 経路は実 PowerPoint 自身の出力なので見た目の確認に
 
 変換器は 3 系統:
 
-- ``auto``（既定）: native PowerPoint → LibreOffice の順に，使えるものを試す．
+- ``auto``（既定）: native PowerPoint → LibreOffice の順に，**使えるもの**を選ぶ．
+  選んだ変換器が失敗したら次へは落とさずそのまま失敗する（Issue #46）．
 - ``powerpoint`` / ``libreoffice``: その系統を名指し．
 - 任意のコマンド行: ``mytool -o {output} {input}`` のように直接指定．
   プレースホルダ ``{input}`` / ``{output}`` / ``{outdir}`` を置換する．1 つも
@@ -55,8 +56,22 @@ class PdfError(Exception):
     """PDF 変換の失敗（原因メッセージ付き）．cli が警告表示に使う．"""
 
 
+class _Unavailable(PdfError):
+    """その変換器がこの環境に**無い**（＝失敗ではない）．
+
+    ``auto`` はこれだけを握って次の変換器へ進む．無い物を飛ばしても何も失われない
+    のに対し，**在る物の失敗**を飛ばすと忠実度の違う PDF を黙って掴ませることに
+    なる（Issue #46）．名指し指定のときは PdfError として そのまま利用者に届く．
+    """
+
+
 # 環境変数名（CLI 引数 --pdf-converter が優先）．
 ENV_CONVERTER = "MD2PPTX_PDF_CONVERTER"
+
+# Windows の COM 経路で「PowerPoint はあった」ことを示す目印．PowerShell に
+# COM オブジェクト生成の直後で出力させ，これが出る前に落ちたか後で落ちたかで
+# 「無い（_Unavailable）」と「失敗（PdfError）」を切り分ける．
+_WIN_COM_READY = "MD2PPTX_POWERPOINT_READY"
 
 # macOS の PowerPoint 変換がこれだけ待っても終わらなければ，ダイアログ待ちを疑って
 # 案内を出す（変換は続ける）．コンテナ経由の変換は例で 1〜8 秒なので誤検知しない幅．
@@ -116,7 +131,7 @@ def _macos_prelaunch_powerpoint_hidden() -> None:
     （利用者が表示して使っているインスタンスを勝手に隠すことはない）．
 
     失敗しても変換は AppleScript 側の暗黙起動で成立するので，ここでは握り潰す
-    （PowerPoint が無い場合の明示エラーは AppleScript の失敗として出る）．
+    （PowerPoint の有無は呼び出し側が先に判定している）．
     """
     try:
         subprocess.run(["open", "-g", "-j", "-a", "Microsoft PowerPoint"],
@@ -192,7 +207,7 @@ def _convert_libreoffice(src: str, dst: str) -> None:
     """LibreOffice で src(pptx) → dst(pdf)．--outdir 方式なので後で改名する．"""
     soffice = _which_libreoffice()
     if soffice is None:
-        raise PdfError(
+        raise _Unavailable(
             "LibreOffice not found (looked for soffice/libreoffice on PATH "
             "and the default install location)")
     outdir = os.path.dirname(os.path.abspath(dst)) or "."
@@ -215,10 +230,18 @@ def _convert_libreoffice(src: str, dst: str) -> None:
 
 
 def _convert_powerpoint(src: str, dst: str) -> None:
-    """native PowerPoint（macOS: AppleScript / Windows: COM）で変換する．"""
+    """native PowerPoint（macOS: AppleScript / Windows: COM）で変換する．
+
+    Raises:
+        _Unavailable: この環境に PowerPoint が無いとき（``auto`` はこれだけを握る）．
+        PdfError: PowerPoint はあったが変換に失敗したとき．
+    """
     src_abs = os.path.abspath(src)
     dst_abs = os.path.abspath(dst)
     if sys.platform == "darwin":
+        if not _macos_powerpoint_installed():
+            raise _Unavailable(
+                "PowerPoint is not installed (no /Applications/Microsoft PowerPoint.app)")
         # macOS は osascript 経由で実 PowerPoint を叩く．
         # スクリプト本体は stdin で，入出力パスは argv で渡す．
         # 文書を開く前に非表示で起動しておく——さもないと変換のたびにウィンドウが出る．
@@ -243,18 +266,31 @@ def _convert_powerpoint(src: str, dst: str) -> None:
         src_ps = src_abs.replace("'", "''")
         dst_ps = dst_abs.replace("'", "''")
         ps = (
-            # COM の失敗は既定では非ゼロ終了にならず _run の returncode 検査を
-            # すり抜ける．Stop にして例外＝非ゼロで終わらせ、原因を拾えるようにする．
+            # COM の失敗は既定では非ゼロ終了にならず returncode 検査をすり抜ける．
+            # Stop にして例外＝非ゼロで終わらせ、原因を拾えるようにする．
             "$ErrorActionPreference = 'Stop'; "
             "$ppt = New-Object -ComObject PowerPoint.Application; "
+            # ここまで来れば PowerPoint は在る．以降の失敗は「無い」ではなく「失敗」．
+            f"Write-Output '{_WIN_COM_READY}'; "
             "$pres = $ppt.Presentations.Open("
             f"'{src_ps}', $true, $false, $false); "
             f"$pres.SaveAs('{dst_ps}', 32); "
             "$pres.Close(); $ppt.Quit()"
         )
-        _run(["powershell", "-NoProfile", "-Command", ps], "powerpoint")
+        try:
+            proc = subprocess.run(["powershell", "-NoProfile", "-Command", ps],
+                                  capture_output=True, text=True)
+        except FileNotFoundError:
+            raise _Unavailable("powerpoint: command not found: powershell")
+        if proc.returncode != 0:
+            detail = (proc.stderr or proc.stdout or "").strip().splitlines()
+            tail = detail[-1] if detail else f"exit {proc.returncode}"
+            if _WIN_COM_READY not in (proc.stdout or ""):
+                # COM オブジェクトすら作れなかった＝PowerPoint が入っていない．
+                raise _Unavailable(f"PowerPoint is not available: {tail}")
+            raise PdfError(f"powerpoint failed: {tail}")
     else:
-        raise PdfError("native PowerPoint is only available on macOS or Windows")
+        raise _Unavailable("native PowerPoint is only available on macOS or Windows")
     # osascript/COM はいずれも無音失敗（exit 0 でも PDF が無い/空）がありうるので，
     # 終了コードだけでなく成果物の存在と非空を成功条件にする．
     if not os.path.isfile(dst_abs) or os.path.getsize(dst_abs) == 0:
@@ -330,7 +366,8 @@ def convert(src: str, dst: str, converter: str | None) -> None:
             それ以外は任意のコマンド行として解釈する．
 
     Raises:
-        PdfError: 変換に失敗したとき（cli が警告に整形する）．
+        PdfError: 変換に失敗したとき（cli が警告に整形する）．``auto`` でも，
+            **使える変換器が失敗したら**そのまま失敗する（次の変換器へは落とさない）．
     """
     if not os.path.isfile(src):
         raise PdfError(f"pptx not found: {src}")
@@ -354,27 +391,29 @@ def convert(src: str, dst: str, converter: str | None) -> None:
     name = (converter or "auto").strip()
 
     if name == "auto":
-        # 実 PowerPoint（テーマ忠実度が高い）→ LibreOffice の順に試す．PowerPoint を試すのは
-        # Windows，または macOS で PowerPoint.app がインストールされている場合．未インストール
-        # や変換失敗時は LibreOffice へフォールバックする．
-        errors: list[str] = []
-        try_powerpoint = sys.platform.startswith("win") or (
-            sys.platform == "darwin" and _macos_powerpoint_installed())
-        if try_powerpoint:
-            try:
-                _convert_powerpoint(src, dst)
-                return
-            except PdfError as e:
-                errors.append(str(e))
+        # auto は「**使えるものを探す**」だけ．実 PowerPoint（テーマ忠実度が高い）を
+        # 優先し，無ければ LibreOffice を使う．
+        # 在る物が失敗したときに次へ落とすことはしない（Issue #46）——忠実度という
+        # 成果物の性質が黙って入れ替わるうえ，隠れる原因（オートメーション承認の拒否，
+        # ライセンス未認証など）は利用者が直せるものだから．
+        missing: list[str] = []
+        try:
+            _convert_powerpoint(src, dst)
+            return
+        except _Unavailable as e:
+            missing.append(str(e))
+        except PdfError as e:
+            raise PdfError(
+                f"{e}; use --pdf-converter libreoffice to convert without PowerPoint")
         try:
             _convert_libreoffice(src, dst)
             return
-        except PdfError as e:
-            errors.append(str(e))
+        except _Unavailable as e:
+            missing.append(str(e))
         raise PdfError(
             "no PDF converter available "
             "(tried PowerPoint / LibreOffice; use --pdf-converter or install "
-            "LibreOffice)\n  - " + "\n  - ".join(errors))
+            "LibreOffice)\n  - " + "\n  - ".join(missing))
 
     if name == "libreoffice":
         _convert_libreoffice(src, dst)

--- a/md2pptx/pdf.py
+++ b/md2pptx/pdf.py
@@ -401,10 +401,15 @@ def convert(src: str, dst: str, converter: str | None) -> None:
             _convert_powerpoint(src, dst)
             return
         except _Unavailable as e:
+            # _Unavailable は PdfError のサブクラスなので，この except は必ず
+            # PdfError より**先**に置くこと．入れ替えると失敗まで握って次の変換器へ
+            # 落ちる＝#46 で消した挙動が黙って戻る．
             missing.append(str(e))
         except PdfError as e:
-            raise PdfError(
-                f"{e}; use --pdf-converter libreoffice to convert without PowerPoint")
+            # 案内は LibreOffice が実際に使えるときだけ添える（無い物を勧めない）．
+            alt = ("; use --pdf-converter libreoffice to convert without PowerPoint"
+                   if _which_libreoffice() else "")
+            raise PdfError(f"{e}{alt}")
         try:
             _convert_libreoffice(src, dst)
             return


### PR DESCRIPTION
Resolves #46

> **base は `main` ではなく `issue-44-suppress-powerpoint-window`（PR #45）です。** `pdf.py` / README.md / DESIGN.md の同じ範囲を #45 が既に書き換えているため、stacked にして衝突を避けています。この PR を #45 のブランチへ merge してから #45 の作業を続け、最後に #45 を main へ merge します。

## 背景

`auto` は「PowerPoint → LibreOffice の順に試す」という 1 つのルールで、性質の違う 2 つの判断をしていました。

1. **PowerPoint が無いので LibreOffice を使う** — 正しい。何も失われない
2. **PowerPoint はあるが失敗したので LibreOffice を使う** — 忠実度という成果物の性質が黙って入れ替わる

2 が問題です。しかも隠れる失敗は**利用者が直せるもの**（オートメーション承認の拒否・ライセンス未認証・PowerPoint 上に開いたままのシート）で、一度その状態になると毎回静かに LibreOffice 出力が返ります。普段 PowerPoint 品質の PDF を見ている人には、これが「md2pptx の組版バグ」に見えます。

## 変更

- `_Unavailable(PdfError)` を導入し、バックエンドが「**無い**」と「**失敗した**」を区別して投げられるようにした
- `auto` は `_Unavailable` のときだけ次へ進み、失敗はそのまま上げる。その際 `--pdf-converter libreoffice` を案内する
- 可用性の判定
  - macOS: `/Applications/Microsoft PowerPoint.app` の有無
  - LibreOffice: `soffice` / `libreoffice` が見つかるか
  - Windows: **COM オブジェクトを作れたか**。PowerShell に `New-Object` 直後で成功マーカーを出させ、マーカー前に落ちたら「無い」、後なら「失敗」と分類する（従来は Windows なら無条件に COM を叩いていたので、そのまま「失敗＝エラー」にすると PowerPoint 未導入の Windows が LibreOffice に落ちなくなる退行が起きる。それを防ぐための切り分け）

## 確認

macOS・PowerPoint 導入済みで 4 パターンを実測しました。

| 条件 | 結果 |
|---|---|
| 通常 | 成功。Producer = Quartz PDFContext、303,146 bytes |
| AppleScript を強制的にエラーにする | `PdfError`。**LibreOffice に落ちず**、PDF も書かれない |
| PowerPoint 未導入相当（判定を false に） | LibreOffice 26.2.4.2 で成功、234,201 bytes |
| どちらも無い | 2 つの理由を並べた 1 つのエラー |

失敗時のメッセージ:

```
powerpoint failed: 22:41: execution error: simulated failure (-1); use --pdf-converter libreoffice to convert without PowerPoint
```

- `mypy --no-incremental`（キャッシュ削除後）: エラー 0
- CLI 通し: `--pdf` で 14 ページ、Producer = Microsoft PowerPoint

Windows 経路は手元に環境が無いため未実行です（CI にも PowerPoint はありません）。COM の分類は PowerShell の出力マーカーに依存しています。

## ドキュメント

README.md（`auto` は失敗しても切り替えない旨）、DESIGN.md §7（可用性と失敗の切り分け）、CLAUDE.md を更新しました。
