### PR TITLE
test: cover the converter and timeout decisions with pytest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,20 @@ jobs:
       - run: pip install -e ".[dev]"
       - run: mypy
 
+  # Unit tests for decisions the other jobs cannot see. generate/pdf exercise the
+  # happy path, so a branch can invert — auto swallowing a failure, the timeout
+  # policy flipping — while the deck and its page count stay identical (#49).
+  # These start no external process, so one interpreter is enough.
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.14"
+      - run: pip install -e ".[dev]"
+      - run: pytest
+
   generate:
     runs-on: ubuntu-latest
     strategy:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,10 +18,11 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-# 型チェック用（実行には不要）．CI と手元で同じものを入れる．
+# 型チェックと単体テスト用（実行には不要）．CI と手元で同じものを入れる．
 dev = [
     "mypy>=1.11",
     "types-PyYAML>=6",
+    "pytest>=8",
 ]
 
 [project.urls]
@@ -36,6 +37,9 @@ packages = ["md2pptx"]
 # バージョンは md2pptx/__init__.py の __version__ を単一の情報源にする（二重管理を避ける）．
 [tool.setuptools.dynamic]
 version = { attr = "md2pptx.__version__" }
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
 
 [tool.mypy]
 files = ["md2pptx"]

--- a/tests/test_pdf_converter_choice.py
+++ b/tests/test_pdf_converter_choice.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""変換器の選び方を固定するテスト（Issue #46 / #49）．
+
+守りたいのは **auto が探索だけを行い、失敗の肩代わりをしない**こと．
+`pdf.convert` から呼ばれるバックエンドを差し替えるので，PowerPoint も
+LibreOffice も要らず，外部プロセスを一切起こさない．
+
+このテストが無いと壊れても気づけない：`except _Unavailable` を
+`except PdfError` の後ろへ動かしても mypy は通り，`example.md` の生成も
+PDF のページ数も変わらない．気づけるのは「PowerPoint が失敗する環境で
+出てきた PDF の組版が違う」ときだけで，それは #46 が無くそうとした
+見つけにくさそのもの．
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from md2pptx import pdf
+
+
+@pytest.fixture
+def deck(tmp_path):
+    """変換の入力に見せかける pptx（中身は読まれない）．"""
+    src = tmp_path / "slide.pptx"
+    src.write_bytes(b"not really a pptx")
+    return src
+
+
+@pytest.fixture
+def called(monkeypatch):
+    """どのバックエンドが呼ばれたかを記録し，好きな結果を返させる．
+
+    使い方: ``called.setup(powerpoint=..., libreoffice=...)``．値が例外なら
+    送出し，そうでなければ「成功して PDF を書いた」ことにする．
+    """
+    log: list[str] = []
+
+    def setup(powerpoint=None, libreoffice=None):
+        def make(name, outcome):
+            def backend(src, dst, timeout=None):
+                log.append(name)
+                if isinstance(outcome, Exception):
+                    raise outcome
+                with open(dst, "wb") as f:
+                    f.write(b"%PDF-1.4 " + name.encode())
+            return backend
+
+        monkeypatch.setattr(pdf, "_convert_powerpoint", make("powerpoint", powerpoint))
+        monkeypatch.setattr(pdf, "_convert_libreoffice", make("libreoffice", libreoffice))
+
+    return SimpleNamespace(log=log, setup=setup)
+
+
+def test_auto_skips_a_converter_that_is_not_installed(deck, tmp_path, called):
+    """**無い**ものは飛ばす——何も失われないので黙って次へ進んでよい．"""
+    called.setup(powerpoint=pdf._Unavailable("no PowerPoint here"), libreoffice=None)
+
+    dst = tmp_path / "out.pdf"
+    pdf.convert(str(deck), str(dst), "auto", timeout=1)
+
+    assert called.log == ["powerpoint", "libreoffice"]
+    assert dst.read_bytes().endswith(b"libreoffice")
+
+
+def test_auto_stops_when_an_installed_converter_fails(deck, tmp_path, called):
+    """**在る**ものの失敗は握らない（Issue #46）．
+
+    ここで LibreOffice へ落ちると，忠実度という成果物の性質が黙って
+    入れ替わり，利用者が直せる原因（承認の拒否など）も隠れてしまう．
+    """
+    called.setup(powerpoint=pdf.PdfError("powerpoint failed: boom"), libreoffice=None)
+
+    dst = tmp_path / "out.pdf"
+    with pytest.raises(pdf.PdfError) as excinfo:
+        pdf.convert(str(deck), str(dst), "auto", timeout=1)
+
+    assert called.log == ["powerpoint"], "LibreOffice へ落ちてはいけない"
+    assert "boom" in str(excinfo.value)
+    assert not dst.exists(), "失敗したのに PDF が残ってはいけない"
+
+
+def test_failure_points_at_libreoffice_only_when_it_is_there(deck, tmp_path, called,
+                                                            monkeypatch):
+    """案内は行き先があるときだけ．無い物を勧めない．"""
+    called.setup(powerpoint=pdf.PdfError("powerpoint failed: boom"))
+
+    monkeypatch.setattr(pdf, "_which_libreoffice", lambda: "/usr/bin/soffice")
+    with pytest.raises(pdf.PdfError) as found:
+        pdf.convert(str(deck), str(tmp_path / "a.pdf"), "auto", timeout=1)
+    assert "--pdf-converter libreoffice" in str(found.value)
+
+    monkeypatch.setattr(pdf, "_which_libreoffice", lambda: None)
+    with pytest.raises(pdf.PdfError) as missing:
+        pdf.convert(str(deck), str(tmp_path / "b.pdf"), "auto", timeout=1)
+    assert "--pdf-converter libreoffice" not in str(missing.value)
+
+
+def test_auto_reports_both_reasons_when_nothing_is_installed(deck, tmp_path, called):
+    """どちらも無いときだけ「変換器が無い」と言う．"""
+    called.setup(powerpoint=pdf._Unavailable("no PowerPoint here"),
+                 libreoffice=pdf._Unavailable("no LibreOffice here"))
+
+    with pytest.raises(pdf.PdfError) as excinfo:
+        pdf.convert(str(deck), str(tmp_path / "out.pdf"), "auto", timeout=1)
+
+    message = str(excinfo.value)
+    assert "no PDF converter available" in message
+    assert "no PowerPoint here" in message and "no LibreOffice here" in message
+
+
+@pytest.mark.parametrize("name", ["powerpoint", "libreoffice"])
+def test_naming_a_converter_reports_that_it_is_missing(deck, tmp_path, called, name):
+    """名指しなら「無い」もそのまま利用者へ届く（勝手に別の物を使わない）．"""
+    called.setup(powerpoint=pdf._Unavailable("no PowerPoint here"),
+                 libreoffice=pdf._Unavailable("no LibreOffice here"))
+
+    with pytest.raises(pdf.PdfError) as excinfo:
+        pdf.convert(str(deck), str(tmp_path / "out.pdf"), name, timeout=1)
+
+    assert called.log == [name]
+    assert "no PDF converter available" not in str(excinfo.value)
+
+
+class TestCustomCommand:
+    """任意コマンド指定．ツールが PDF をどこへ書くかは指定形式で決まる．"""
+
+    def _run(self, monkeypatch, command, src, dst, writes):
+        """変換器コマンドを実行せず，``writes(cmd)`` で成果物を作らせる．"""
+        seen: list[list[str]] = []
+
+        def fake_run(cmd, what, input=None, timeout=None):
+            seen.append(cmd)
+            writes(cmd)
+
+        monkeypatch.setattr(pdf, "_run", fake_run)
+        pdf.convert(str(src), str(dst), command, timeout=1)
+        return seen[0]
+
+    def test_output_placeholder_is_written_in_place(self, deck, tmp_path, monkeypatch):
+        dst = tmp_path / "named.pdf"
+        cmd = self._run(monkeypatch, "mytool -o {output} {input}", deck, dst,
+                        lambda cmd: open(cmd[2], "wb").write(b"%PDF"))
+        assert cmd == ["mytool", "-o", str(dst), str(deck)]
+        assert dst.exists()
+
+    def test_outdir_placeholder_collects_the_input_basename(self, deck, tmp_path,
+                                                            monkeypatch):
+        """soffice 方式：出力先ディレクトリに <入力 basename>.pdf を書く．"""
+        dst = tmp_path / "renamed.pdf"
+        self._run(monkeypatch, "soffice --outdir {outdir} {input}", deck, dst,
+                  lambda cmd: open(tmp_path / "slide.pdf", "wb").write(b"%PDF"))
+        assert dst.exists(), "入力名の PDF を出力先の名前へ揃えること"
+        assert not (tmp_path / "slide.pdf").exists()
+
+    def test_a_tool_without_placeholders_gets_the_input_appended(self, deck, tmp_path,
+                                                                 monkeypatch):
+        """出力先を取れないツール：入力を末尾に足し，その隣の PDF を回収する．"""
+        dst = tmp_path / "out.pdf"
+        cmd = self._run(monkeypatch, "convert-to-pdf", deck, dst,
+                        lambda cmd: open(deck.with_suffix(".pdf"), "wb").write(b"%PDF"))
+        assert cmd == ["convert-to-pdf", str(deck)]
+        assert dst.exists()
+
+    def test_a_tool_that_writes_nothing_is_a_failure(self, deck, tmp_path, monkeypatch):
+        dst = tmp_path / "out.pdf"
+        with pytest.raises(pdf.PdfError):
+            self._run(monkeypatch, "mytool {output}", deck, dst, lambda cmd: None)

--- a/tests/test_pdf_converter_choice.py
+++ b/tests/test_pdf_converter_choice.py
@@ -14,6 +14,7 @@ PDF のページ数も変わらない．気づけるのは「PowerPoint が失�
 """
 from __future__ import annotations
 
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -44,8 +45,7 @@ def called(monkeypatch):
                 log.append(name)
                 if isinstance(outcome, Exception):
                     raise outcome
-                with open(dst, "wb") as f:
-                    f.write(b"%PDF-1.4 " + name.encode())
+                Path(dst).write_bytes(b"%PDF-1.4 " + name.encode())
             return backend
 
         monkeypatch.setattr(pdf, "_convert_powerpoint", make("powerpoint", powerpoint))
@@ -142,7 +142,7 @@ class TestCustomCommand:
     def test_output_placeholder_is_written_in_place(self, deck, tmp_path, monkeypatch):
         dst = tmp_path / "named.pdf"
         cmd = self._run(monkeypatch, "mytool -o {output} {input}", deck, dst,
-                        lambda cmd: open(cmd[2], "wb").write(b"%PDF"))
+                        lambda cmd: Path(cmd[2]).write_bytes(b"%PDF"))
         assert cmd == ["mytool", "-o", str(dst), str(deck)]
         assert dst.exists()
 
@@ -151,7 +151,7 @@ class TestCustomCommand:
         """soffice 方式：出力先ディレクトリに <入力 basename>.pdf を書く．"""
         dst = tmp_path / "renamed.pdf"
         self._run(monkeypatch, "soffice --outdir {outdir} {input}", deck, dst,
-                  lambda cmd: open(tmp_path / "slide.pdf", "wb").write(b"%PDF"))
+                  lambda cmd: (tmp_path / "slide.pdf").write_bytes(b"%PDF"))
         assert dst.exists(), "入力名の PDF を出力先の名前へ揃えること"
         assert not (tmp_path / "slide.pdf").exists()
 
@@ -160,7 +160,7 @@ class TestCustomCommand:
         """出力先を取れないツール：入力を末尾に足し，その隣の PDF を回収する．"""
         dst = tmp_path / "out.pdf"
         cmd = self._run(monkeypatch, "convert-to-pdf", deck, dst,
-                        lambda cmd: open(deck.with_suffix(".pdf"), "wb").write(b"%PDF"))
+                        lambda cmd: deck.with_suffix(".pdf").write_bytes(b"%PDF"))
         assert cmd == ["convert-to-pdf", str(deck)]
         assert dst.exists()
 

--- a/tests/test_pdf_timeout.py
+++ b/tests/test_pdf_timeout.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""待ちの上限とその決め方を固定するテスト（Issue #48 / #49）．
+
+守りたいのは **人が見ているかどうかで待ち方を変える**という判断．承認ダイアログの
+ように「人が今すぐ直せる」停止では待つ意味があるので tty では打ち切らず，誰も応答
+できない環境（cron / CI / エディタ拡張）でだけ打ち切る．
+
+外部プロセスは起こさない．``subprocess`` を差し替えて挙動だけを見る．
+"""
+from __future__ import annotations
+
+import subprocess
+from types import SimpleNamespace
+
+import pytest
+
+from md2pptx import pdf
+
+
+@pytest.fixture(autouse=True)
+def no_env(monkeypatch):
+    """環境変数の影響を受けないようにする（実行環境で結果が変わらないため）．"""
+    monkeypatch.delenv(pdf.ENV_TIMEOUT, raising=False)
+
+
+@pytest.fixture
+def stderr_is(monkeypatch):
+    """stderr が tty かどうかを差し替える．出力も拾えるようにする．"""
+    def use(tty: bool):
+        written: list[str] = []
+        fake = SimpleNamespace(isatty=lambda: tty, write=written.append)
+        monkeypatch.setattr(pdf.sys, "stderr", fake)
+        return written
+    return use
+
+
+class TestPolicy:
+    """上限の決め方：明示 > 環境変数 > tty かどうか．"""
+
+    def test_a_terminal_waits_for_the_person(self, stderr_is):
+        """tty では打ち切らない——30 秒の案内で直してもらえる見込みがある．"""
+        stderr_is(True)
+        assert pdf._resolve_timeout(None) is None
+
+    def test_nobody_watching_means_give_up(self, stderr_is):
+        """非 tty では誰も応答しないので待っても状況は変わらない．"""
+        stderr_is(False)
+        assert pdf._resolve_timeout(None) == pdf._TIMEOUT_UNATTENDED
+
+    def test_the_environment_overrides_the_default(self, monkeypatch, stderr_is):
+        stderr_is(True)          # tty でも環境変数が勝つ
+        monkeypatch.setenv(pdf.ENV_TIMEOUT, "42")
+        assert pdf._resolve_timeout(None) == 42.0
+
+    def test_the_option_overrides_the_environment(self, monkeypatch, stderr_is):
+        stderr_is(False)
+        monkeypatch.setenv(pdf.ENV_TIMEOUT, "42")
+        assert pdf._resolve_timeout(7.0) == 7.0
+
+    def test_zero_asks_for_no_limit(self, stderr_is):
+        stderr_is(False)
+        assert pdf._resolve_timeout(0.0) is None
+
+    @pytest.mark.parametrize("bad", [-5.0, float("nan"), float("inf")])
+    def test_values_that_are_not_a_duration_are_rejected(self, bad, stderr_is):
+        """特に負値：``-5``（``5`` の打ち間違い）を無制限と読むと，この機能が
+        防ごうとしている「無人で永久に待つ」状態そのものを作ってしまう．"""
+        stderr_is(False)
+        with pytest.raises(pdf.PdfError, match="0 = no limit"):
+            pdf._resolve_timeout(bad)
+
+    def test_a_junk_environment_value_is_rejected(self, monkeypatch, stderr_is):
+        stderr_is(False)
+        monkeypatch.setenv(pdf.ENV_TIMEOUT, "soon")
+        with pytest.raises(pdf.PdfError, match=pdf.ENV_TIMEOUT):
+            pdf._resolve_timeout(None)
+
+    def test_the_limit_reaches_the_converter(self, tmp_path, monkeypatch, stderr_is):
+        """決めた上限が実際にバックエンドへ渡ること．"""
+        stderr_is(False)
+        seen: list[float | None] = []
+
+        def backend(src, dst, timeout=None):
+            seen.append(timeout)
+            open(dst, "wb").write(b"%PDF")
+
+        monkeypatch.setattr(pdf, "_convert_libreoffice", backend)
+        src = tmp_path / "slide.pptx"
+        src.write_bytes(b"x")
+        pdf.convert(str(src), str(tmp_path / "out.pdf"), "libreoffice")
+        assert seen == [pdf._TIMEOUT_UNATTENDED]
+
+
+class FakeProc:
+    """``communicate`` が最初は時間切れになり，2 回目で返る子プロセス．"""
+
+    def __init__(self, calls_before_return=1, returncode=0):
+        self.remaining = calls_before_return
+        self.returncode = returncode
+        self.timeouts: list[float | None] = []
+        self.killed = False
+
+    def communicate(self, input=None, timeout=None):
+        self.timeouts.append(timeout)
+        if self.remaining > 0:
+            self.remaining -= 1
+            raise subprocess.TimeoutExpired(cmd="osascript", timeout=timeout or 0)
+        return ("", "")
+
+    def kill(self):
+        self.killed = True
+        self.remaining = 0
+
+
+class TestSlowPowerPoint:
+    """案内を出したあとの振る舞い（macOS 経路）．"""
+
+    def _patch(self, monkeypatch, proc):
+        opened: list[list[str]] = []
+        monkeypatch.setattr(pdf.subprocess, "Popen", lambda *a, **k: proc)
+        monkeypatch.setattr(pdf.subprocess, "run",
+                            lambda cmd, **k: opened.append(cmd) or SimpleNamespace(
+                                returncode=0, stdout="", stderr=""))
+        return opened
+
+    def test_a_terminal_gets_the_notice_and_powerpoint_up_front(self, tmp_path,
+                                                                monkeypatch, stderr_is):
+        written = stderr_is(True)
+        proc = FakeProc()
+        opened = self._patch(monkeypatch, proc)
+
+        dst = tmp_path / "out.pdf"
+        dst.write_bytes(b"%PDF")     # 成功したことにする（存在と非空だけ見る）
+        pdf._macos_run_applescript(str(tmp_path / "in.pptx"), str(dst), None)
+
+        assert "taking longer" in "".join(written)
+        assert any("Microsoft PowerPoint" in " ".join(cmd) for cmd in opened), \
+            "tty では前面に出して応答してもらう"
+        assert proc.timeouts[-1] is None, "tty なら 2 回目は無制限に待つ"
+        assert not proc.killed
+
+    def test_without_a_terminal_nothing_is_brought_to_the_front(self, tmp_path,
+                                                               monkeypatch, stderr_is):
+        """非 tty での前面化は，押せないダイアログのために作業画面を奪うだけ．"""
+        written = stderr_is(False)
+        proc = FakeProc()
+        opened = self._patch(monkeypatch, proc)
+
+        dst = tmp_path / "out.pdf"
+        dst.write_bytes(b"%PDF")
+        pdf._macos_run_applescript(str(tmp_path / "in.pptx"), str(dst), None)
+
+        assert "taking longer" in "".join(written)
+        assert opened == [], "前面化してはいけない"
+
+    def test_giving_up_kills_only_our_child(self, tmp_path, monkeypatch, stderr_is):
+        stderr_is(False)
+        proc = FakeProc(calls_before_return=2)   # 2 回とも時間切れ
+        self._patch(monkeypatch, proc)
+
+        with pytest.raises(pdf.PdfError, match="timed out after 60s"):
+            pdf._macos_run_applescript(str(tmp_path / "in.pptx"),
+                                       str(tmp_path / "out.pdf"), 60.0)
+        assert proc.killed, "打ち切るなら起こした子は回収する"
+
+    def test_a_limit_below_the_notice_gives_up_without_it(self, tmp_path, monkeypatch,
+                                                          stderr_is):
+        """上限が案内より短ければ，案内を待たずにそこで打ち切る．"""
+        written = stderr_is(False)
+        proc = FakeProc(calls_before_return=2)
+        self._patch(monkeypatch, proc)
+
+        with pytest.raises(pdf.PdfError, match="timed out after 5s"):
+            pdf._macos_run_applescript(str(tmp_path / "in.pptx"),
+                                       str(tmp_path / "out.pdf"), 5.0)
+        # 1 回目が上限そのもの（案内の 30 秒を待たない）．続く 10.0 は kill 後の回収．
+        assert proc.timeouts[0] == 5.0
+        assert "taking longer" not in "".join(written)

--- a/tests/test_pdf_timeout.py
+++ b/tests/test_pdf_timeout.py
@@ -11,6 +11,7 @@
 from __future__ import annotations
 
 import subprocess
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -83,7 +84,7 @@ class TestPolicy:
 
         def backend(src, dst, timeout=None):
             seen.append(timeout)
-            open(dst, "wb").write(b"%PDF")
+            Path(dst).write_bytes(b"%PDF")
 
         monkeypatch.setattr(pdf, "_convert_libreoffice", backend)
         src = tmp_path / "slide.pptx"


### PR DESCRIPTION
Resolves #49

## 背景

いまの CI は「デッキが組み上がること」しか見ていません。**どの分岐が組み上げたか**は見ていないので、この 2 つが逆転しても検出できません。

- `auto` が「無い変換器」だけを飛ばす（#46）
- 「人が見ているときだけ待ち続ける」（#48）

どちらを壊しても `example.md` は 14 枚のまま、PDF も 14 ページのままです。症状は「出てきた PDF の組版が違う」か「ジョブが返ってこない」だけで、これは両 Issue が消そうとした**見つけにくさそのもの**です。

## 変更

pytest を導入し（`dev` 依存 + `[tool.pytest.ini_options]` + CI ジョブ）、24 件のテストを追加しました。**外部プロセスは一切起こしません**（バックエンドと `subprocess` を差し替え）。PowerPoint も LibreOffice も不要で、実行時間は 0.04 秒です。

**`tests/test_pdf_converter_choice.py`** — 変換器の選択

- 無い変換器は飛ばす／**在る変換器の失敗は握らない**
- 名指しでは「無い」もそのまま利用者へ届く
- 案内（`--pdf-converter libreoffice`）は LibreOffice が見つかるときだけ付く
- 失敗時に書きかけ PDF を残さない
- 任意コマンドのプレースホルダ解釈（`{output}` / `{outdir}` / 無指定で `{input}` を補う）

**`tests/test_pdf_timeout.py`** — 待ちの上限

- 優先順位（明示 > 環境変数 > tty 判定）、`0` は無制限、負値・`nan`・`inf` は誤り
- 決めた上限がバックエンドまで届くこと
- 案内のあと、**tty では無制限に待ち PowerPoint を前面に出す／非 tty では前面化しない**
- 打ち切りでは自分の子だけを kill する
- 上限が案内より短ければ案内を待たずに打ち切る

Issue の起票時点では #48 が未実装だったので、対象を広げています。

## 「本当に守れるか」の確認

テストを書いた後、**`except _Unavailable` を `except PdfError` の後ろへ動かして**（コード中のコメントが警告しているまさにその誤り）実行しました。

```
FAILED tests/test_pdf_converter_choice.py::test_auto_stops_when_an_installed_converter_fails
       - Failed: DID NOT RAISE PdfError
FAILED tests/test_pdf_converter_choice.py::test_failure_points_at_libreoffice_only_when_it_is_there
       - Failed: DID NOT RAISE PdfError
2 failed, 8 passed
```

このとき mypy は通り、生成されるデッキも変わりません。既存 CI では素通りする退行を、追加したテストが捕まえられています。復元後は 24 件すべて通ります。

## 確認

- `pytest`: 24 passed
- `mypy --no-incremental`（キャッシュ削除後）: エラー 0。`files = ["md2pptx"]` のままなので `tests/` は型検査の対象外です
- CI に `test` ジョブを追加（`pip install -e ".[dev]"` → `pytest`）。外部プロセスを使わないので処理系は 1 つで足ります

## 今後

`parser.py` と `flow.py` は python-pptx 非依存の純モジュールなので、この基盤の上に同様のテストを足せます。この PR では #49 の範囲（変換器の選択）と、そこに隣接する #48 の分岐に絞りました。
