### PR TITLE
docs: wire --watch up to VS Code

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,12 @@
+{
+  // PDF を LaTeX Workshop の内蔵ビューアで開く。**ディスク上の更新を検知して自動で
+  // 読み直す**のがこれを選ぶ理由で、md2pptx が PDF をアトミックに差し替えるのと
+  // 組み合わさって「保存 → 数秒でプレビューが更新」が成立する（README 参照）。
+  //
+  // LaTeX Workshop（James-Yu.latex-workshop）が要る。入れていない場合、PDF を開くと
+  // 「このビューアが無い」と言われるので、この行を消すか右クリック →
+  // 「エディターの再度オープン」で既定に戻す。
+  "workbench.editorAssociations": {
+    "*.pdf": "latex-workshop-pdf-hook"
+  }
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,88 @@
+// md2pptx を VS Code から使うためのタスク定義。
+//
+// 中身は README の「VS Code で編集しながらプレビューする」節と同じもので、
+// ここに置いてあるのは example.md で実際に動かして確かめるため（ドッグフーディング）。
+// **片方だけ直さないこと**——直したらもう片方も揃える。
+//
+// problemMatcher が読む 2 行（`rebuilding` / `watching for changes`）は md2pptx 側との
+// 契約。変えると background task が「走り終わった」と判定できなくなる。
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      // 編集中の Markdown を見張り続ける。Cmd-Shift-P →「タスクの実行」→ これ。
+      "label": "md2pptx: watch",
+      "type": "shell",
+      "command": "md2pptx",
+      "args": ["${file}", "--watch", "--pdf"],
+      "options": { "cwd": "${fileDirname}" },
+      "isBackground": true,
+      "presentation": {
+        // 端末は出さない（PDF を見ていればよい）。問題は Problems パネルに出る。
+        // 端末も見たいときは "always" にする。
+        "reveal": "silent",
+        "panel": "dedicated",
+        "clear": true,
+        "close": false
+      },
+      // 同じ md を二重に見張らない。
+      "runOptions": { "instanceLimit": 1 },
+      "problemMatcher": {
+        "owner": "md2pptx",
+        "source": "md2pptx",
+        "fileLocation": ["autoDetect", "${fileDirname}"],
+        "severity": "error",
+        "pattern": {
+          // md2pptx: failed to parse /path/slide.md: invalid YAML front matter at line 2: ...
+          // md2pptx: failed to render /path/slide.md: image not found: fig.png
+          //
+          // 拾うのは**ファイルに紐づく失敗だけ**。`converting to PDF: out.pdf` や
+          // `no theme specified` を診断にしないため、接頭辞まで含めて照合する。
+          // パスは非貪欲——理由の側に別の `.md:` が出ても先頭で切る。
+          "kind": "file",
+          "regexp": "^md2pptx: failed to (?:parse|render) (.+?\\.md): (.+)$",
+          "file": 1,
+          "message": 2
+        },
+        "background": {
+          "activeOnStart": true,
+          "beginsPattern": "^md2pptx: \\d\\d:\\d\\d:\\d\\d rebuilding\\b",
+          "endsPattern": "^md2pptx: \\d\\d:\\d\\d:\\d\\d watching for changes\\b"
+        }
+      }
+    },
+    {
+      // 単発ビルド（Cmd-Shift-B の既定）。
+      "label": "md2pptx: build",
+      "type": "shell",
+      "command": "md2pptx",
+      "args": ["${file}", "--pdf"],
+      "options": { "cwd": "${fileDirname}" },
+      "group": { "kind": "build", "isDefault": true },
+      "presentation": { "reveal": "silent", "panel": "dedicated", "clear": true },
+      "problemMatcher": {
+        "owner": "md2pptx",
+        "source": "md2pptx",
+        "fileLocation": ["autoDetect", "${fileDirname}"],
+        "severity": "error",
+        "pattern": {
+          "kind": "file",
+          "regexp": "^md2pptx: failed to (?:parse|render) (.+?\\.md): (.+)$",
+          "file": 1,
+          "message": 2
+        }
+      }
+    },
+    {
+      // 出来上がった PDF を開く（.vscode/settings.json の関連付けで内蔵ビューアへ）。
+      // `code` コマンドが PATH に要る（コマンドパレット →
+      // 「Shell Command: Install 'code' command in PATH」）。
+      "label": "md2pptx: open preview",
+      "type": "shell",
+      "command": "code",
+      "args": ["-r", "${fileDirname}/${fileBasenameNoExtension}.pdf"],
+      "presentation": { "reveal": "never" },
+      "problemMatcher": []
+    }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -60,6 +60,8 @@
       "options": { "cwd": "${fileDirname}" },
       "group": { "kind": "build", "isDefault": true },
       "presentation": { "reveal": "silent", "panel": "dedicated", "clear": true },
+      // pattern は上の watch と同じもの。tasks.json にはカスタム matcher を名前で
+      // 使い回す仕組みが無いので写すしかない——**直すときは 2 か所とも直すこと**。
       "problemMatcher": {
         "owner": "md2pptx",
         "source": "md2pptx",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,10 +139,16 @@ macOS 経路は **PowerPoint を目立たせずに使う**（Issue #44）。何�
   → また作る」の無限ループになる。
 - **`rebuilding` / `watching for changes` の 2 行は VS Code 側との契約**（`problemMatcher.background`
   が走行中の判定に使う）。変えるなら `.vscode/tasks.json` と README も一緒に直す。
+  `failed to parse|render <md>: <理由>` も同様に problemMatcher が読む（Problems パネルの診断）。
 - **SIGTERM を `KeyboardInterrupt` へ寄せるのは watch のときだけ**。既定の即死だと `finally` が
   走らず、エディタの「タスクの終了」で PDF 変換の作業ディレクトリが残る。一発実行には入れない。
 
 画像パスの解決規則は `render.resolve_image_path` に集約してある（描画側と監視側で二重管理しない）。
+
+`.vscode/tasks.json` は **README の「VS Code で編集しながらプレビューする」節と同じ内容**を
+置いている（ここでは `example.md` で実際に動かして確かめるため）。**片方だけ直さないこと。**
+`.vscode/settings.json` の `editorAssociations` は LaTeX Workshop の内蔵ビューア（自動リロード
+対応）へ PDF を向けるもので、これが無いと保存しても画面が変わらない。
 
 ## 規約・設計上の約束
 

--- a/README.md
+++ b/README.md
@@ -169,6 +169,10 @@ md2pptx: 14:04:07 rebuilding slide.md (fig.png changed)
 LaTeX Workshop のリアルタイムプレビューと同じ体験になります。**保存すると数秒で PDF の
 タブが更新されます**（タブは開いたまま、スクロール位置も保たれます）。
 
+以下は **macOS を前提**に書いています。Windows / Linux でも同じ仕組みで動きますが、キーは
+`Cmd` を `Ctrl` に読み替えてください（オートメーション承認は macOS だけの話です。Windows の
+PowerPoint 変換は COM 経由なので承認は要りません）。
+
 必要なものは 2 つです。
 
 1. **[LaTeX Workshop](https://marketplace.visualstudio.com/items?itemName=James-Yu.latex-workshop)**
@@ -239,6 +243,8 @@ LaTeX Workshop のリアルタイムプレビューと同じ体験になりま�
       "options": { "cwd": "${fileDirname}" },
       "group": { "kind": "build", "isDefault": true },
       "presentation": { "reveal": "silent", "panel": "dedicated", "clear": true },
+      // pattern は上の watch と同じもの。tasks.json にはカスタム matcher を名前で
+      // 使い回す仕組みが無いので写すしかない——**直すときは 2 か所とも直すこと**。
       "problemMatcher": {
         "owner": "md2pptx",
         "source": "md2pptx",
@@ -278,6 +284,9 @@ LaTeX Workshop のリアルタイムプレビューと同じ体験になりま�
   { "key": "cmd+alt+t", "command": "workbench.action.tasks.terminate" }
 ]
 ```
+
+`workbench.action.tasks.terminate` は **md2pptx 専用ではありません**。実行中のタスクが複数あると
+どれを止めるか尋ねられるので、そこで `md2pptx: watch` を選んでください。
 
 使い方と注意です。
 

--- a/README.md
+++ b/README.md
@@ -164,6 +164,142 @@ md2pptx: 14:04:07 rebuilding slide.md (fig.png changed)
   しまうためです。止まった PowerPoint を前面に出すこともしません（編集画面を奪わないため）。
   `--pdf-timeout` で変えられます。
 
+#### VS Code で編集しながらプレビューする
+
+LaTeX Workshop のリアルタイムプレビューと同じ体験になります。**保存すると数秒で PDF の
+タブが更新されます**（タブは開いたまま、スクロール位置も保たれます）。
+
+必要なものは 2 つです。
+
+1. **[LaTeX Workshop](https://marketplace.visualstudio.com/items?itemName=James-Yu.latex-workshop)**
+   （`James-Yu.latex-workshop`）。`.tex` と無関係の PDF も開けて、**ディスク上の更新を検知して
+   自動で読み直す**ビューアを持っているのが理由です。LaTeX を使っていなくても構いません。
+   - `vscode-pdf`（`tomoki1207.pdf`）は自動リロードが壊れたままなので使えません
+     （[Issue #162](https://github.com/tomoki1207/vscode-pdfviewer/issues/162)）。
+   - VS Code 内にこだわらないなら、外部ビューアでも同じことができます（macOS なら
+     [Skim](https://skim-app.sourceforge.io/) が自動リロードに対応。プレビュー.app は非対応）。
+2. **PDF をそのビューアに関連付ける。** `.vscode/settings.json`（またはユーザー設定）に:
+
+```jsonc
+{
+  "workbench.editorAssociations": { "*.pdf": "latex-workshop-pdf-hook" }
+}
+```
+
+あとはタスクを置くだけです。原稿のリポジトリの `.vscode/tasks.json` に貼ってください
+（このリポジトリにも同じものが入っているので、`example.md` で試せます）。
+
+```jsonc
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      // 編集中の Markdown を見張り続ける。Cmd-Shift-P →「タスクの実行」→ これ。
+      "label": "md2pptx: watch",
+      "type": "shell",
+      "command": "md2pptx",
+      "args": ["${file}", "--watch", "--pdf"],
+      "options": { "cwd": "${fileDirname}" },
+      "isBackground": true,
+      "presentation": {
+        // 端末は出さない（PDF を見ていればよい）。問題は Problems パネルに出る。
+        // 端末も見たいときは "always" にする。
+        "reveal": "silent",
+        "panel": "dedicated",
+        "clear": true,
+        "close": false
+      },
+      // 同じ md を二重に見張らない。
+      "runOptions": { "instanceLimit": 1 },
+      "problemMatcher": {
+        "owner": "md2pptx",
+        "source": "md2pptx",
+        "fileLocation": ["autoDetect", "${fileDirname}"],
+        "severity": "error",
+        "pattern": {
+          // 拾うのはファイルに紐づく失敗だけ（`converting to PDF: ...` を診断にしない）。
+          "kind": "file",
+          "regexp": "^md2pptx: failed to (?:parse|render) (.+?\\.md): (.+)$",
+          "file": 1,
+          "message": 2
+        },
+        "background": {
+          "activeOnStart": true,
+          "beginsPattern": "^md2pptx: \\d\\d:\\d\\d:\\d\\d rebuilding\\b",
+          "endsPattern": "^md2pptx: \\d\\d:\\d\\d:\\d\\d watching for changes\\b"
+        }
+      }
+    },
+    {
+      // 単発ビルド（Cmd-Shift-B の既定）。
+      "label": "md2pptx: build",
+      "type": "shell",
+      "command": "md2pptx",
+      "args": ["${file}", "--pdf"],
+      "options": { "cwd": "${fileDirname}" },
+      "group": { "kind": "build", "isDefault": true },
+      "presentation": { "reveal": "silent", "panel": "dedicated", "clear": true },
+      "problemMatcher": {
+        "owner": "md2pptx",
+        "source": "md2pptx",
+        "fileLocation": ["autoDetect", "${fileDirname}"],
+        "severity": "error",
+        "pattern": {
+          "kind": "file",
+          "regexp": "^md2pptx: failed to (?:parse|render) (.+?\\.md): (.+)$",
+          "file": 1,
+          "message": 2
+        }
+      }
+    },
+    {
+      // 出来上がった PDF を開く（上の関連付けで内蔵ビューアへ）。`code` コマンドが
+      // PATH に要る（コマンドパレット → 「Shell Command: Install 'code' command in PATH」）。
+      "label": "md2pptx: open preview",
+      "type": "shell",
+      "command": "code",
+      "args": ["-r", "${fileDirname}/${fileBasenameNoExtension}.pdf"],
+      "presentation": { "reveal": "never" },
+      "problemMatcher": []
+    }
+  ]
+}
+```
+
+キーバインドを付けるなら `keybindings.json` へ（`args` では変数が展開されないので、タスク名で
+呼びます）。
+
+```jsonc
+[
+  { "key": "cmd+alt+w", "command": "workbench.action.tasks.runTask",
+    "args": "md2pptx: watch", "when": "editorLangId == markdown" },
+  { "key": "cmd+alt+v", "command": "workbench.action.tasks.runTask",
+    "args": "md2pptx: open preview", "when": "editorLangId == markdown" },
+  { "key": "cmd+alt+t", "command": "workbench.action.tasks.terminate" }
+]
+```
+
+使い方と注意です。
+
+- **`md2pptx: watch` を 1 回実行して、あとは書くだけ**です。PDF のタブを開いておくと、保存の
+  たびに更新されます。止めるときは「タスクの終了」（`Cmd-Alt-T`）。
+- **`${file}` はタスクを実行した時点の Markdown に固定されます。** 別の原稿に切り替えたら、
+  タスクを終了して実行し直してください。原稿が 1 つに決まっているなら、`${file}` の代わりに
+  `"${workspaceFolder}/slide.md"` と書いておく方が事故がありません。
+- **文法エラーは Problems パネルに出ます**（該当行を含むメッセージ付き）。テーマ未指定のような
+  ファイルに紐づかないエラーは端末にだけ出るので、見落としが気になるなら `presentation` の
+  `"reveal"` を `"always"` にしてください。
+- **`md2pptx: open preview` は「Markdown の隣に同じ名前の PDF ができる」前提**です
+  （`slide.md` → `slide.pdf`）。フロントマターの `output:` を別の場所や名前にしているときは、
+  タスクの `args` をその PDF のパスに書き換えてください。一度開いてしまえば、以降はタブが
+  自動で更新されるので、このタスクを使うのは最初の 1 回だけです。
+- **初回だけ macOS のオートメーション承認が要ります**（PowerPoint で変換する場合）。
+  「"Code" が "Microsoft PowerPoint" を制御しようとしています」というダイアログが出るので許可
+  してください。承認は**呼び出し元アプリごと**なので、Terminal で承認済みでも VS Code では
+  改めて出ます。押し損ねても 180 秒で諦めるだけなので、次の保存でまた出ます。
+- **PowerPoint を使いたくない場合**は `--pdf-converter libreoffice` を `args` に足してください
+  （GUI も承認も不要。ただし忠実度は当たり確認どまりです）。
+
 ### 試す
 
 ```bash
@@ -475,6 +611,7 @@ caption: 実験結果の比較
 | `md2pptx/flow.py` | フロー図 DSL のパーサ＋レイアウタ |
 | `md2pptx/pdf.py` | pptx → PDF 変換（`--pdf`） |
 | `md2pptx/watch.py` | 入力の変更監視（`--watch`） |
+| `.vscode/` | VS Code のタスク定義と PDF ビューアの関連付け（上記の節と同じ内容） |
 | `example.md` | 機能ひととおりのデモ |
 | `DESIGN.md` | 詳細設計 |
 


### PR DESCRIPTION
## 背景

#53 で PDF がアトミックに差し替わるようになり、#54 で保存を検知して作り直すようになりました。部品は揃っているのに、**エディタからどう動かすかがどこにも書かれていない**のが残りです。この PR でタスク定義とその説明を足して、「タスクを 1 回実行したら、あとは書くだけ」にします。

コード変更はありません（`.vscode/` の新規 2 ファイルと、README / CLAUDE.md への追記のみ）。

## PDF ビューアに LaTeX Workshop を使う理由

`.tex` と無関係の PDF も開けて、**ディスク上の更新を検知して自動で読み直す**からです。md2pptx 側だけでは供給できない半分がこれで、#53 のアトミック差し替えと噛み合って「保存 → 数秒でタブが更新（スクロール位置も保持）」が成立します。

`vscode-pdf`（`tomoki1207.pdf`）は自動リロードが 2023 年から壊れたままなので使えない旨を明記しました（[Issue #162](https://github.com/tomoki1207/vscode-pdfviewer/issues/162)）。

**両方の拡張が `*.pdf` にビューアを登録する**ため、`editorAssociations` は形式的な設定ではなく**どちらが開くかを決める実質的な指定**です。この環境で実際に確認しました:

```
$ code --list-extensions | grep -iE "latex-workshop|tomoki1207"
james-yu.latex-workshop
tomoki1207.pdf

$ # james-yu.latex-workshop 10.16.1 の package.json
viewType: latex-workshop-pdf-hook | selector: [{'filenamePattern': '*.pdf'}, {'filenamePattern': '*.PDF'}]
```

## problemMatcher

診断にするのは**ファイルに紐づく失敗だけ**（`failed to parse|render <md>: <理由>`）にしました。

```
"regexp": "^md2pptx: failed to (?:parse|render) (.+?\\.md): (.+)$"
```

実際の出力 15 行に対して判定を確認しています——進捗行・`saved:`・`converting to PDF: out.pdf`・テーマ未指定・`unsupported theme format`・空白を含むパス・**理由側に別の `.md:` を含む行**まで含めて、意図した 3 分類（診断／begins／ends）に全件一致しました。`converting to PDF: out.pdf` が診断にならないこと、パスを非貪欲に切ること（`a.md: cannot read b.md: nope` → `file=a.md`）が要点です。

watch タスクを通しで動かした結果（画像を消す → 戻す）:

```
md2pptx: 00:59:03 rebuilding WD/example.md          → タスク実行中（beginsPattern）
md2pptx: converting to PDF: example.pdf
md2pptx: 00:59:07 watching for changes              ← タスク待機中（endsPattern）
md2pptx: 00:59:11 rebuilding WD/example.md (example-fig.png changed)
md2pptx: failed to render WD/example.md: image not found: example-fig.png
                                                     診断  file=WD/example.md
                                                           message=image not found: example-fig.png
md2pptx: 00:59:11 watching for changes
md2pptx: 00:59:15 rebuilding WD/example.md (example-fig.png changed)
md2pptx: converting to PDF: example.pdf
md2pptx: 00:59:18 watching for changes
```

各リビルドが begins / ends の対で囲まれ、エラーのときだけ診断が 1 件出て、直すと消えます。

## tasks.json をリポジトリにも置く

README に全文を載せつつ、`.vscode/tasks.json` としてもコミットしています。このリポジトリには `example.md` があるので**実際に動かして確かめられる**のと、動かされない設定は腐るためです。両者が JSON として一致していることを機械的に確認し、CLAUDE.md に「片方だけ直さないこと」と書きました。

タスクは 3 つです。

| ラベル | 用途 |
|---|---|
| `md2pptx: watch` | 編集中の Markdown を見張り続ける（background task） |
| `md2pptx: build` | 単発ビルド（`Cmd-Shift-B` の既定） |
| `md2pptx: open preview` | 出来上がった PDF を開く（最初の 1 回だけ） |

## 既知の制限（README に明記）

- **`${file}` はタスク実行時点の Markdown に固定**されます。別の原稿に切り替えたらタスクを再実行してください。原稿が 1 つに決まっているなら `"${workspaceFolder}/slide.md"` と固定する方が事故がありません。
- **`open preview` は「Markdown の隣に同じ名前の PDF」を前提**にしています。フロントマターの `output:` が別の場所や名前を指しているときは、タスクの `args` を書き換える必要があります。
- ファイルに紐づかないエラー（テーマ未指定など）は Problems パネルに出ず端末にだけ出るので、`presentation.reveal` を `"always"` にする選択肢を案内しています。
- macOS の初回オートメーション承認は**呼び出し元アプリごと**なので、Terminal で承認済みでも VS Code では改めて出ます。押し損ねても 180 秒で諦めるだけで、次の保存でまた出ます。

## 動作確認

- `.vscode/tasks.json` / `.vscode/settings.json` が妥当な JSON（コメント除去後）であること
- README のコード塊と `.vscode/tasks.json` が JSON として一致すること
- `latex-workshop-pdf-hook` が実際に登録されている viewType であること（インストール済み拡張の `package.json` で確認）
- `code` / `md2pptx` が PATH にあること
- `md2pptx: build` 相当をタスクと同じ形（`${file}` は絶対パス、`cwd` は `${fileDirname}`）で実行 → `example.pdf` 837KB 生成、終了コード 0
- `md2pptx: watch` 相当を通しで実行 → 上記の判定結果
- `pytest` 68 passed / `mypy` clean（コード変更は無いが確認）

**GUI の実操作（タスク実行 → Problems パネル表示 → PDF タブの自動更新）は手元での目視確認が残ります。** 出力形式・正規表現・viewType・コマンドの実行可否まではすべて機械的に確認済みです。

## これで完成すること

```bash
md2pptx slide.md --watch --pdf     # または VS Code で「md2pptx: watch」
```

保存 → 約 2 秒で PDF タブが更新される、という LaTeX Workshop 相当の編集体験になります。
