### PR TITLE
refactor: give flow tokens a type instead of a tuple shape

### DIFF
--- a/md2pptx/flow.py
+++ b/md2pptx/flow.py
@@ -20,6 +20,7 @@ DSL 例::
 from __future__ import annotations
 
 import re
+from dataclasses import dataclass
 from typing import Literal
 
 from .ir import Flow, FlowNode, FlowEdge
@@ -46,6 +47,32 @@ _RE_SETTING = re.compile(r"^(direction|caption|note\(top\)|note\(bottom\))\s*:\s
 _RE_NODE = re.compile(r"\[([^\]]*)\](?:\{([\w-]+)\})?")
 # エッジ "->" / "-PR->"．先頭の '-' から '->' まで．
 _RE_EDGE = re.compile(r"-(?:([^>]+?)-)?>")
+
+
+# ---------------------------------------------------------------- トークン
+
+# 字句解析の途中結果．**ir.FlowNode / FlowEdge とは別物**で，こちらは構文解析の
+# 作業用（``_make_node`` がこれを IR へ変換する）．混同を避けるため私有名にしてある．
+#
+# 種類ごとに別の型にしているのは，持っている情報が違うから．ノードは色を持ち，
+# エッジは持たない——これを 1 つのタプルに詰めると，読む側が「今どちらなのか」を
+# 憶えていないと添字を間違える（それを型で言えないのが Issue #34）．
+
+@dataclass(frozen=True)
+class _NodeTok:
+    """``[ラベル | サブ]`` ／ ``[…]{色}``．``label`` は ``|`` で割る前の生の中身．"""
+    label: str
+    color: str | None = None
+
+
+@dataclass(frozen=True)
+class _EdgeTok:
+    """``->`` ／ ``-ラベル->``．``label`` が None なら文字の無い矢印．"""
+    label: str | None = None
+
+
+# requires-python が 3.11 なので実行時に評価される ``|`` を使える．
+_Token = _NodeTok | _EdgeTok
 
 
 # ---------------------------------------------------------------- パース
@@ -82,14 +109,13 @@ def parse_flow(text: str) -> Flow:
     return flow
 
 
-def _tokenize(s: str):
+def _tokenize(s: str) -> list[_Token]:
     """ノード／エッジのトークン列を返す（出現順）．
 
     ノード "[…]"／エッジ "->" 以外の文字列はタイポの可能性が高いので
     黙殺せずエラーにする（設定行は parse_flow が先に取り除いている）．
     """
-    # ("node", label, color) と ("edge", label) が混在するので要素長は一定でない．
-    tokens: list[tuple] = []
+    tokens: list[_Token] = []
     i, n = 0, len(s)
     while i < n:
         c = s[i]
@@ -103,7 +129,7 @@ def _tokenize(s: str):
                     f"unclosed flow node (missing ']'): {s[i:i + 30]!r}")
             inner = s[i + 1:j]
             i = j + 1
-            color = None
+            color: str | None = None
             if i < n and s[i] == "{":
                 k = s.find("}", i)
                 if k < 0:
@@ -112,12 +138,12 @@ def _tokenize(s: str):
                         f"{s[i:i + 30]!r}")
                 color = s[i + 1:k]
                 i = k + 1
-            tokens.append(("node", inner, color))
+            tokens.append(_NodeTok(inner, color))
             continue
         if c == "-":
             m = _RE_EDGE.match(s, i)
             if m:
-                tokens.append(("edge", (m.group(1) or "").strip() or None))
+                tokens.append(_EdgeTok((m.group(1) or "").strip() or None))
                 i = m.end()
                 continue
         raise ValueError(
@@ -126,28 +152,32 @@ def _tokenize(s: str):
     return tokens
 
 
-def _build(flow: Flow, tokens) -> None:
-    """トークン列（node / edge の交互）から nodes / edges を構築する．"""
-    pending_label = None
-    have_pending_edge = False
-    prev_idx = None
+def _build(flow: Flow, tokens: list[_Token]) -> None:
+    """トークン列（node / edge の交互）から nodes / edges を構築する．
+
+    エッジは 2 つのノードに挟まれて初めて線になるので，``->`` を読んだ時点では
+    まだ引けない——次のノードが来るまで「保留中の矢印」として持ち越す．
+    相手が現れないまま終われば（``-> [A]`` の先頭や ``[A] ->`` の末尾），
+    その矢印は捨てる．
+    """
+    pending: _EdgeTok | None = None
+    prev_idx: int | None = None
 
     for tok in tokens:
-        if tok[0] == "node":
-            node = _make_node(tok[1], tok[2])
-            flow.nodes.append(node)
+        if isinstance(tok, _NodeTok):
+            flow.nodes.append(_make_node(tok.label, tok.color))
             idx = len(flow.nodes) - 1
-            if have_pending_edge and prev_idx is not None:
-                flow.edges.append(FlowEdge(src=prev_idx, dst=idx, label=pending_label))
+            if pending is not None and prev_idx is not None:
+                flow.edges.append(
+                    FlowEdge(src=prev_idx, dst=idx, label=pending.label))
             prev_idx = idx
-            have_pending_edge = False
-            pending_label = None
-        else:  # edge
-            have_pending_edge = True
-            pending_label = tok[1]
+            pending = None
+        else:
+            # ``->`` が続いた場合は上書き（覚えておけるのは直前の 1 本だけ）．
+            pending = tok
 
 
-def _make_node(inner: str, color) -> FlowNode:
+def _make_node(inner: str, color: str | None) -> FlowNode:
     parts = inner.split("|", 1)
     label = parts[0].strip()
     sublabel = parts[1].strip() if len(parts) > 1 else None

--- a/tests/test_flow_parse.py
+++ b/tests/test_flow_parse.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""フロー図 DSL の解釈を固定するテスト（Issue #34 の足場）．
+
+``flow.py`` の中間表現をタプルから dataclass へ移すにあたり，**移す前に**書いた．
+中身を入れ替える変更なので，見るべきは「入力に対して同じ Flow が出るか」であって
+トークンの持ち方ではない——だからこのファイルは ``parse_flow`` / ``plan_flow`` という
+**外から見える 2 つの関数だけ**を叩く．``_tokenize`` や ``_NodeTok`` には触れない
+（触ると，構造を変えるたびにテストごと書き換えることになり，守るものが無くなる）．
+
+DSL の仕様として DESIGN.md に書いてあるのは主要な形だけで，**端の挙動は
+どこにも書かれていない**．書かれていないものは変わっても気づけないので，
+現状の挙動をここに写しておく（「こうあるべき」ではなく「いまこうである」）．
+"""
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from md2pptx import flow as F
+
+
+# ------------------------------------------------------------ 基本の形
+
+def test_it_reads_the_pipeline_from_example_md():
+    """example.md の「生成パイプライン」——DSL の要素が一通り出てくる唯一の実例．"""
+    f = F.parse_flow(
+        "direction: lr\n"
+        "note(top): テーマと Markdown を入力に pptx を生成\n"
+        "[theme.thmx | テーマ]\n"
+        "-変換-> [base.pptx | 土台]\n"
+        "-描画-> [out.pptx | スライド]\n"
+        "caption: 配色・フォントはテーマ、内容は Markdown\n"
+        "note(bottom): → テーマを差し替えるだけで見た目が一新できる")
+
+    assert f.direction == "lr"
+    assert f.caption == "配色・フォントはテーマ、内容は Markdown"
+    assert f.note_top == "テーマと Markdown を入力に pptx を生成"
+    assert f.note_bottom == "→ テーマを差し替えるだけで見た目が一新できる"
+
+    assert [n.label for n in f.nodes] == ["theme.thmx", "base.pptx", "out.pptx"]
+    assert [n.sublabel for n in f.nodes] == ["テーマ", "土台", "スライド"]
+    assert [(e.src, e.dst, e.label) for e in f.edges] == [
+        (0, 1, "変換"), (1, 2, "描画")]
+
+
+def test_nodes_and_edges_may_share_a_line():
+    """1 行に詰めても行ごとに分けても同じ——行は連結されてから解釈される．"""
+    packed = F.parse_flow("[A] -> [B] -> [C]")
+    spread = F.parse_flow("[A]\n-> [B]\n-> [C]")
+
+    assert [n.label for n in packed.nodes] == [n.label for n in spread.nodes]
+    assert [(e.src, e.dst) for e in packed.edges] == [(0, 1), (1, 2)]
+
+
+def test_an_edge_without_a_label_has_none():
+    """``->`` と ``-ラベル->`` の違いはラベルの有無だけ（空文字ではなく None）．"""
+    f = F.parse_flow("[A] -> [B] -x-> [C]")
+
+    assert [e.label for e in f.edges] == [None, "x"]
+
+
+@pytest.mark.parametrize("src, label, sublabel", [
+    ("[A | sub]", "A", "sub"),
+    ("[A]", "A", None),
+    ("[A|]", "A", None),              # 区切りだけ書いても空のサブラベルは持たない
+    ("[ | ]", "", None),
+    ("[  ]", "", None),
+    ("[|B]", "", "B"),                # ラベルが空でもサブラベルは生きる
+    ("[A | b | c]", "A", "b | c"),    # 区切りは最初の 1 個だけ
+])
+def test_how_a_node_label_splits(src, label, sublabel):
+    """``|`` の扱い．空白は落とし，空になったサブラベルは None にする．"""
+    node = F.parse_flow(src).nodes[0]
+
+    assert (node.label, node.sublabel) == (label, sublabel)
+
+
+def test_a_color_can_follow_a_node():
+    """``{...}`` はノードの色．付いていないノードは None のまま．"""
+    f = F.parse_flow("[A]{accent2} -> [B]")
+
+    assert [n.color for n in f.nodes] == ["accent2", None]
+
+
+def test_a_color_does_not_need_a_space_before_the_next_node():
+    """``[A]{c}[B]`` のように詰めても 2 ノードに割れる（色の閉じで区切れる）．"""
+    f = F.parse_flow("[A]{c1}[B]")
+
+    assert [(n.label, n.color) for n in f.nodes] == [("A", "c1"), ("B", None)]
+
+
+@pytest.mark.parametrize("label", ["…", "..."])
+def test_an_ellipsis_node_is_a_kind_of_its_own(label):
+    """``…`` / ``...`` は「途中を省いた」印で，ふつうの箱とは描き方が違う．"""
+    f = F.parse_flow(f"[A] -> [{label}] -> [B]")
+
+    assert [n.kind for n in f.nodes] == ["box", "ellipsis", "box"]
+
+
+# ------------------------------------------------------- 端の挙動（記録）
+
+def test_an_edge_with_nothing_on_one_side_is_dropped():
+    """繋ぐ先が無いエッジは黙って消える．
+
+    ``-> [A] ->`` は前後に相手がいないので線が引けない．**エラーにはしない**——
+    書きかけの原稿でよく通る形で，ここで止めると編集しながらのプレビューが使えない．
+    """
+    f = F.parse_flow("-> [A] ->")
+
+    assert [n.label for n in f.nodes] == ["A"]
+    assert f.edges == []
+
+
+def test_nodes_side_by_side_are_not_connected():
+    """矢印を書かずに並べたノードは繋がらない．
+
+    ``[A] -> [B] [C]`` で B–C 間に線が出ないこと——保留中の矢印を使い切ったら
+    忘れる，という一点で決まっている．忘れ損ねると，1 本書いた矢印が以降の
+    ノード全部に伝染して，**書いていない線が図に増える**．
+    """
+    f = F.parse_flow("[A] -x-> [B] [C]")
+
+    assert [n.label for n in f.nodes] == ["A", "B", "C"]
+    assert [(e.src, e.dst, e.label) for e in f.edges] == [(0, 1, "x")]
+
+
+def test_only_the_last_of_consecutive_edges_survives():
+    """``->`` が続いたら線は 1 本，ラベルは**最後のものが残る**．
+
+    ``-先-> -後-> [B]`` で「先」が消えるのは意図した設計ではなく，
+    次のノードを待つ間ラベルを 1 つしか覚えていないことの帰結．変えるなら
+    それは仕様変更であって，リファクタリングで静かに変わってよいものではない．
+    """
+    f = F.parse_flow("[A] -先-> -後-> [B]")
+
+    assert [(e.src, e.dst, e.label) for e in f.edges] == [(0, 1, "後")]
+
+
+def test_an_empty_diagram_is_not_an_error():
+    """ノードが 0 個でも通る（``` ```flow ``` を開いた直後の状態）．"""
+    assert F.parse_flow("").nodes == []
+    assert F.parse_flow("->").nodes == []
+
+
+def test_settings_are_taken_from_anywhere_in_the_block():
+    """設定行は図の途中に挟んでもよい（行の位置で意味が変わらない）．"""
+    f = F.parse_flow("[A]\ndirection: tb\n-> [B]\ncaption: あとがき")
+
+    assert (f.direction, f.caption) == ("tb", "あとがき")
+    assert [(e.src, e.dst) for e in f.edges] == [(0, 1)]
+
+
+@pytest.mark.parametrize("key, attr", [
+    ("caption", "caption"), ("note(top)", "note_top"),
+    ("note(bottom)", "note_bottom"),
+])
+def test_a_setting_with_an_empty_value_stays_none(key, attr):
+    """``caption:`` と書いて中身が無いのは「指定しなかった」と同じ扱い．"""
+    assert getattr(F.parse_flow(f"[A]\n{key}:"), attr) is None
+
+
+# --------------------------------------------------------- 誤りの伝え方
+
+@pytest.mark.parametrize("src, message", [
+    ("[unclosed",     "unclosed flow node (missing ']')"),
+    ("[A]{unclosed",  "unclosed flow node color (missing '}')"),
+    ("junk",          "invalid flow syntax"),
+    ("[A] ~ [B]",     "invalid flow syntax"),
+    ("[A] - [B]",     "invalid flow syntax"),   # '-' だけでは矢印にならない
+    ("[A] -x- [B]",   "invalid flow syntax"),   # '>' で閉じていない
+    ("direction: ne", "invalid flow direction"),
+])
+def test_it_refuses_rather_than_ignores(src, message):
+    """読めない字はタイポの可能性が高いので黙って捨てない．
+
+    捨てると，矢印を書いたつもりの図が線の無い図として出てきて，原因が分からない．
+    """
+    with pytest.raises(ValueError, match=re.escape(message)):
+        F.parse_flow(src)
+
+
+def test_the_error_shows_where_it_gave_up():
+    """メッセージに問題の箇所を入れる（どこを直すかが分からないと意味がない）．"""
+    with pytest.raises(ValueError, match="~ここ"):
+        F.parse_flow("[A] ~ここ~ [B]")
+
+
+# --------------------------------------------------------- 配置（#26）
+
+# 主軸方向の大きさを取り出す添字．boxes / ellipses はどちらも
+# (中身, l, t, w, h) の並びで，lr なら w，tb なら h を見る．
+_MAIN_AXIS = {"lr": 3, "tb": 4}
+
+
+def _slots(plan, direction):
+    """箱と省略記号を並び順に戻し，(省略記号か, 主軸方向の大きさ) の列を返す．"""
+    axis = _MAIN_AXIS[direction]
+    pos = 1 if direction == "lr" else 2              # l / t
+    items = ([(b[pos], False, b[axis]) for b in plan["boxes"]]
+             + [(e[pos], True, e[axis]) for e in plan["ellipses"]])
+    return [(is_ellipsis, size) for _, is_ellipsis, size in sorted(items)]
+
+
+@pytest.mark.parametrize("direction", ["lr", "tb"])
+def test_an_ellipsis_takes_a_narrower_slot_than_a_box(direction):
+    """省略記号は固定の小さい枠を取り，浮いた分を箱が使う（Issue #26）．
+
+    「…」は 1 文字の注記なので箱と同じ幅は要らない．等分に配ると，省略を 1 つ
+    挟んだだけで箱が 1 つ増えたのと同じだけ痩せる——書いている側から見ると
+    理由の分からない縮み方になる．
+
+    「箱がまったく縮まない」わけではない（枠 1 つ分と間隔は増える）．
+    確かめたいのは**省略記号のほうが箱より狭く，その差だけ箱が得をする**こと．
+    """
+    src = f"direction: {direction}\n" + "{}"
+    area = (0, 0, F.EMU * 6, F.EMU * 4)   # 上下限に張り付かない大きさを選ぶ
+    with_box = _slots(
+        F.plan_flow(F.parse_flow(src.format("[A] -> [X] -> [B]")), *area),
+        direction)
+    with_gap = _slots(
+        F.plan_flow(F.parse_flow(src.format("[A] -> [… | ] -> [B]")), *area),
+        direction)
+
+    assert [s[0] for s in with_gap] == [False, True, False], "真ん中が省略記号"
+    assert with_gap[1][1] < with_gap[0][1], "省略記号の枠は箱より狭い"
+    assert with_gap[0][1] > with_box[0][1], "その分だけ箱が広く取れている"
+
+
+@pytest.mark.parametrize("direction", ["lr", "tb"])
+def test_it_draws_one_arrow_per_edge(direction):
+    """エッジの本数だけ矢印が出る．ラベル付きのものにだけ文字が付く．"""
+    plan = F.plan_flow(
+        F.parse_flow(f"direction: {direction}\n[A] -> [B] -付き-> [C]"),
+        0, 0, F.EMU * 8, F.EMU * 4)
+
+    assert len(plan["arrows"]) == 2
+    assert [lb[0] for lb in plan["labels"]] == ["付き"]
+
+
+def test_a_caption_sits_below_the_boxes():
+    """キャプションは図の下（離れて間延びしないよう箱の直下に付ける）．"""
+    plan = F.plan_flow(F.parse_flow("[A] -> [B]\ncaption: 説明"),
+                       0, 0, F.EMU * 8, F.EMU * 4)
+
+    (text, _left, top, _w, _h, role), = plan["captions"]
+    box_bottom = max(b[2] + b[4] for b in plan["boxes"])
+
+    assert (text, role) == ("説明", "caption")
+    assert top >= box_bottom
+
+
+def test_notes_are_not_drawn_here():
+    """note(top) / note(bottom) は地の文なので，図の座標プランには出てこない．
+
+    本文プレースホルダへ入れるのは render の仕事（DESIGN.md の分担）．
+    ここで箱を作ってしまうと二重に描かれる．
+    """
+    plan = F.plan_flow(
+        F.parse_flow("[A]\nnote(top): 上\nnote(bottom): 下\ncaption: 中"),
+        0, 0, F.EMU * 8, F.EMU * 4)
+
+    assert [c[0] for c in plan["captions"]] == ["中"]
+
+
+def test_an_empty_flow_plans_nothing():
+    """ノードが無ければ何も置かない（空の枠だけが残らないように）．"""
+    plan = F.plan_flow(F.parse_flow(""), 0, 0, F.EMU * 8, F.EMU * 4)
+
+    assert all(v == [] for v in plan.values())


### PR DESCRIPTION
Resolves #34

`flow.py` の字句解析が積むトークンを、タプルから dataclass に替える。`flow.py` の中だけで完結し、`ir.py` にも公開 API にも波及しない。

## 問題

`_tokenize` は 2 種類のタプルを積んでいた。

```python
tokens.append(("node", inner, color))                        # 3 要素・color は str | None
tokens.append(("edge", (m.group(1) or "").strip() or None))  # 2 要素
```

消費側の `_build` は `tok[0] == "node"` で分岐して `tok[1]` / `tok[2]` を読む。**タグ付きユニオンを手書きしている**状態で、長さも要素の型も揃っていないため `list[tuple]` は実質 `list[Any]` に落ちる。エッジに `tok[2]` を読めば実行時の `IndexError` で、型チェッカには見えない。

正確な型を書こうとすると `tuple[Literal["node"], str, str | None] | tuple[Literal["edge"], str | None]` になり、書いても読む側で narrowing が要る。**注釈で解ける問題ではなく、中間表現をタプルで持っていること自体が原因**（#32 のレビューで 2 回指摘され、構造の変更として切り出した経緯）。

## 変更

`_NodeTok` / `_EdgeTok`（frozen dataclass）を定義し、`isinstance` で分岐する。

**もう1つ落ちたものがある。** `_build` は `have_pending_edge`（bool）と `pending_label` の 2 変数を手で同期させていたが、フラグが言っていたのは「保留中の矢印があるか」だけで、**トークンが在ることがすでにそれを言っている**。`pending: _EdgeTok | None` 1 つに畳んだ。

## テスト

`flow.py` にはテストが1件も無かったので、**書き換える前に・古いコードに対して**書いた（37件）。新しいコードがたまたまそう動くことではなく、**もとのコードがそう動いていたこと**を示すため。

対象は `parse_flow` / `plan_flow` の 2 つだけにした。私有トークンを直接押さえると、表現を変えるたびにテストごと書き換えることになる——そして今回動かしているのはまさにその表現なので、守るものが無くなる。

仕様として書かれておらず、変わっても気づけなかった端の挙動も記録した。

| 入力 | いまの結果 |
|---|---|
| `-> [A] ->` | 相手のいない矢印は捨てる（エラーにしない） |
| `[A] -先-> -後-> [B]` | 線は1本、ラベルは後だけ残る |
| `[A] -x-> [B] [C]` | B–C は繋がらない |

ミューテーション確認（実装を壊してテストが落ちるか）を7項目で実施。**1件が生き残った**——「使い終わった矢印を忘れる」処理を消しても全件通ってしまった。1本書いた矢印が以降のノード全部に伝染して**書いていない線が図に増える**経路なので、テストを足して塞いだ。

## 検証

- `pytest` 124 passed（新規37件を含む）
- `mypy --no-incremental` 0件（キャッシュを捨てて CI と同条件）
- `python3 -m md2pptx.parser` の自己検証
- **`example.md` を変更前後で生成し、デッキ全体55図形が種類・座標・文字とも一致**（フロー図スライドを含む）。省略記号の固定幅スロット（#26）もここに含まれる
- 構文エラー7種のメッセージが文字列まで一致
