### PR TITLE
refactor: name the parts of a flow plan instead of numbering them

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,26 +8,7 @@ md2pptx — Markdown と PowerPoint テーマ（thmx / pptx）から発表スラ
 
 ## アーキテクチャ
 
-パイプライン（DESIGN.md §2）:
-
-```
-theme.thmx ──[thmx2pptx]──▶ base.pptx ┐
-                                       ├─▶ [render] ─▶ out.pptx
-input.md ──[parser]──▶ IR(Deck) ───────┘
-```
-
-| ファイル | 役割 |
-|---|---|
-| `pyproject.toml` | パッケージ定義（依存・`md2pptx` コンソールスクリプト = `md2pptx.cli:main`） |
-| `md2pptx/cli.py` | CLI エントリポイント。引数処理・全体結線（`main()`／`python3 -m md2pptx`） |
-| `md2pptx/thmx2pptx.py` | thmx → base pptx 変換（ステージ0）。`theme/`→`ppt/` 等の OPC 操作 |
-| `md2pptx/parser.py` | Markdown → 中間表現（IR）。python-pptx 非依存 |
-| `md2pptx/ir.py` | IR データクラス（`Deck`/`Slide`/`Line`/`Table`/`Flow`/`TitleSlide` 等）。外部依存なし |
-| `md2pptx/render.py` | IR → pptx 描画（`Renderer` クラス）。描画ヘルパーは手書きの参照スクリプトから移植 |
-| `md2pptx/flow.py` | フロー図 DSL のパーサ＋座標レイアウタ。python-pptx 非依存（EMU 計算のみ） |
-| `md2pptx/pdf.py` | pptx → PDF 変換（`--pdf`）。変換器の探索と外部プロセス起動。python-pptx 非依存 |
-| `md2pptx/watch.py` | 入力の変更監視（`--watch`）。stdlib ポーリング。cli にも python-pptx にも非依存 |
-| `md2pptx/workdir.py` | 使い捨て作業ディレクトリの作成と片付け。外部依存なし（render / pdf / thmx2pptx が使う） |
+パイプラインは DESIGN.md §2 を参照。
 
 パッケージ内モジュールは相対 import（`from .ir import …`）で結線する。
 `md2pptx/` はルート直下の flat レイアウト（`pip install .` / `pipx install .` で
@@ -44,25 +25,10 @@ IR を作る／render が IR を描く」の分離を保つ。
 ## コマンド
 
 ```bash
-# 開発中の実行（インストール不要・リポジトリルートで）
-python3 -m md2pptx input.md --theme OfficeTheme.pptx -o out.pptx
-
-# インストール後は md2pptx コマンドで実行
-md2pptx example.md --theme OfficeTheme.pptx -o example.pptx
-
-# インストール（依存も自動導入）
-pipx install .        # 隔離環境（推奨）
-pip install -e .      # editable 開発用
-
-# 型チェック（設定は pyproject.toml の [tool.mypy]。CI と同じもの）
-pip install -e ".[dev]"
-mypy
-
 # 各モジュールの自己検証は -m で（相対 import のみなので直接実行はできない）
 python3 -m md2pptx.parser
 ```
 
-依存: `python-pptx>=1.0` / `PyYAML>=6`（`pyproject.toml` で宣言。インストール時に自動導入）。
 環境は python-pptx 1.0.2 / PyYAML 6で検証。
 
 CI（`.github/workflows/ci.yml`）は3ジョブ。`typecheck` が mypy を1回、`generate` が

--- a/md2pptx/flow.py
+++ b/md2pptx/flow.py
@@ -20,7 +20,7 @@ DSL 例::
 from __future__ import annotations
 
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Literal
 
 from .ir import Flow, FlowNode, FlowEdge
@@ -188,23 +188,83 @@ def _make_node(inner: str, color: str | None) -> FlowNode:
     return FlowNode(label=label, sublabel=sublabel, kind=kind, color=color)
 
 
+# ---------------------------------------------------------------- 配置プラン
+
+# 描画指示（座標はすべて EMU 整数）．render はこれを読んで図形を置くだけで，
+# 位置の計算はここで終わっている．
+#
+# 名前で持つのは，位置で持つと**取り違えても誰も気づかない**から．幅と高さを
+# 入れ替えても，右端と下端を取り違えても，型としては同じ整数で通ってしまい，
+# 図が歪んで出てくるまで分からない（Issue #71）．
+
+@dataclass(frozen=True)
+class Rect:
+    """矩形．端や中心は毎回足し算で出さず，ここから読む．"""
+    left: int
+    top: int
+    width: int
+    height: int
+
+    @property
+    def right(self) -> int:
+        return self.left + self.width
+
+    @property
+    def bottom(self) -> int:
+        return self.top + self.height
+
+    @property
+    def center_x(self) -> int:
+        return self.left + self.width // 2
+
+    @property
+    def center_y(self) -> int:
+        return self.top + self.height // 2
+
+
+@dataclass(frozen=True)
+class PlacedNode:
+    """角丸四角ノード．色・サブラベルを持つので ``node`` ごと渡す．"""
+    node: FlowNode
+    rect: Rect
+
+
+@dataclass(frozen=True)
+class PlacedText:
+    """文字だけの要素（省略記号・矢印ラベル・キャプション）．"""
+    text: str
+    rect: Rect
+
+
+@dataclass(frozen=True)
+class PlacedArrow:
+    """ノード間の矢印．始点から終点への線分で，太さは render が決める．"""
+    x1: int
+    y1: int
+    x2: int
+    y2: int
+
+
+@dataclass
+class FlowPlan:
+    """図ひとつぶんの配置．
+
+    ``note_top`` / ``note_bottom`` はここに入らない——地の文なので本文
+    プレースホルダへ入れるのが render の仕事で，図の座標を持たない．
+    """
+    boxes: list[PlacedNode] = field(default_factory=list)
+    ellipses: list[PlacedText] = field(default_factory=list)
+    arrows: list[PlacedArrow] = field(default_factory=list)
+    labels: list[PlacedText] = field(default_factory=list)
+    captions: list[PlacedText] = field(default_factory=list)
+
+
 # ---------------------------------------------------------------- レイアウト
 
-def plan_flow(flow: Flow, left, top, width, height):
-    """Flow を矩形領域 (left, top, width, height) に配置する座標プランを返す．
-
-    戻り値は描画指示の dict（座標はすべて EMU 整数）::
-
-        {
-          "boxes":  [(FlowNode, l, t, w, h), ...],   # 角丸四角ノード
-          "ellipses": [(label, l, t, w, h), ...],    # "…" ノード
-          "arrows": [(x1, y1, x2, y2), ...],         # 矢印
-          "labels": [(text, l, t, w, h), ...],       # 矢印ラベル
-          "captions": [(text, l, t, w, h, role), ...],  # note_top/caption/note_bottom
-        }
-    """
-    plan: dict[str, list] = {
-        "boxes": [], "ellipses": [], "arrows": [], "labels": [], "captions": []}
+def plan_flow(flow: Flow, left: int, top: int, width: int,
+              height: int) -> FlowPlan:
+    """Flow を矩形領域 (left, top, width, height) に配置する．"""
+    plan = FlowPlan()
     nodes = flow.nodes
     if not nodes:
         return plan
@@ -225,11 +285,13 @@ def plan_flow(flow: Flow, left, top, width, height):
 
     if flow.caption:
         cy = bottom + cap_gap
-        plan["captions"].append((flow.caption, left, cy, width, cap_h, "caption"))
+        plan.captions.append(
+            PlacedText(flow.caption, Rect(left, cy, width, cap_h)))
     return plan
 
 
-def _plan_horizontal(plan, flow, left, top, width, height, cap_reserve):
+def _plan_horizontal(plan: FlowPlan, flow, left, top, width, height,
+                     cap_reserve) -> int:
     """横並び（lr）に配置し，box 帯の下端 y（キャプション基準）を返す．"""
     nodes = flow.nodes
     n = len(nodes)
@@ -252,31 +314,35 @@ def _plan_horizontal(plan, flow, left, top, width, height, cap_reserve):
     group_h = bh + cap_reserve
     by = top + max(0, (height - group_h) // 2)
 
-    centers = []
+    # 置いた矩形はエッジを引くときに端と中心が要るので，そのまま取っておく
+    # （ノードの並び順で引ける）．
+    rects = []
     bl = startx
     for node in nodes:
         w = ew if node.kind == "ellipsis" else bw
+        rect = Rect(bl, by, w, bh)
         if node.kind == "ellipsis":
-            plan["ellipses"].append((node.label or "…", bl, by, w, bh))
+            plan.ellipses.append(PlacedText(node.label or "…", rect))
         else:
-            plan["boxes"].append((node, bl, by, w, bh))
-        centers.append((bl, bl + w // 2, bl + w, by + bh // 2))
+            plan.boxes.append(PlacedNode(node, rect))
+        rects.append(rect)
         bl += w + gx
 
     for e in flow.edges:
         if not (0 <= e.src < n and 0 <= e.dst < n):
             continue
-        a, b = centers[e.src], centers[e.dst]
-        ay = a[3]
-        plan["arrows"].append((a[2], ay, b[0], ay))
+        a, b = rects[e.src], rects[e.dst]
+        ay = a.center_y
+        plan.arrows.append(PlacedArrow(a.right, ay, b.left, ay))
         if e.label:
-            mx = (a[2] + b[0]) // 2
-            plan["labels"].append(
-                (e.label, mx - _emu(0.5), by - _emu(0.5), _emu(1.0), _emu(0.45)))
+            mx = (a.right + b.left) // 2
+            plan.labels.append(PlacedText(e.label, Rect(
+                mx - _emu(0.5), by - _emu(0.5), _emu(1.0), _emu(0.45))))
     return by + bh
 
 
-def _plan_vertical(plan, flow, left, top, width, height, cap_reserve):
+def _plan_vertical(plan: FlowPlan, flow, left, top, width, height,
+                   cap_reserve) -> int:
     """縦並び（tb）に配置し，box 列の下端 y（キャプション基準）を返す．"""
     nodes = flow.nodes
     n = len(nodes)
@@ -296,25 +362,26 @@ def _plan_vertical(plan, flow, left, top, width, height, cap_reserve):
     total = nb * bh + ne * eh + (n - 1) * gy
     starty = top + max(0, (avail - total) // 2)
 
-    centers = []
+    rects = []
     bt = starty
     for node in nodes:
         h = eh if node.kind == "ellipsis" else bh
+        rect = Rect(bx, bt, bw, h)
         if node.kind == "ellipsis":
-            plan["ellipses"].append((node.label or "…", bx, bt, bw, h))
+            plan.ellipses.append(PlacedText(node.label or "…", rect))
         else:
-            plan["boxes"].append((node, bx, bt, bw, h))
-        centers.append((bx + bw // 2, bt, bt + h))
+            plan.boxes.append(PlacedNode(node, rect))
+        rects.append(rect)
         bt += h + gy
 
     for e in flow.edges:
         if not (0 <= e.src < n and 0 <= e.dst < n):
             continue
-        a, b = centers[e.src], centers[e.dst]
-        cx = a[0]
-        plan["arrows"].append((cx, a[2], cx, b[1]))
+        a, b = rects[e.src], rects[e.dst]
+        cx = a.center_x
+        plan.arrows.append(PlacedArrow(cx, a.bottom, cx, b.top))
         if e.label:
-            my = (a[2] + b[1]) // 2
-            plan["labels"].append(
-                (e.label, cx + _emu(0.2), my - _emu(0.22), _emu(1.2), _emu(0.45)))
+            my = (a.bottom + b.top) // 2
+            plan.labels.append(PlacedText(e.label, Rect(
+                cx + _emu(0.2), my - _emu(0.22), _emu(1.2), _emu(0.45))))
     return starty + total

--- a/md2pptx/flow.py
+++ b/md2pptx/flow.py
@@ -251,6 +251,10 @@ class FlowPlan:
 
     ``note_top`` / ``note_bottom`` はここに入らない——地の文なので本文
     プレースホルダへ入れるのが render の仕事で，図の座標を持たない．
+
+    **ここだけ ``frozen`` にしていない．** 中の要素（``Rect`` や ``Placed*``）は
+    作ったら変わらないが，この入れ物は ``_plan_horizontal`` / ``_plan_vertical``
+    が置きながら追記していくため．
     """
     boxes: list[PlacedNode] = field(default_factory=list)
     ellipses: list[PlacedText] = field(default_factory=list)

--- a/md2pptx/render.py
+++ b/md2pptx/render.py
@@ -640,38 +640,43 @@ class Renderer:
         """
         plan = plan_flow(flow, left, top, width, height)
         # box が標準サイズで収まらなければ，全 box 一律で下位レベルへ切り替える．
-        boxes = plan["boxes"]
+        boxes = plan.boxes
         if boxes:
             bsz = self._fit_font(
-                lambda sz: all(self._box_fits(node, bw, bh, sz)
-                               for node, _, _, bw, bh in boxes))
+                lambda sz: all(
+                    self._box_fits(b.node, b.rect.width, b.rect.height, sz)
+                    for b in boxes))
         else:
             bsz = self._body_font_size()
-        bi = 0
-        for node, bl, bt, bw, bh in plan["boxes"]:
-            tc = self._theme_color(node.color) or \
+        for bi, box in enumerate(boxes):
+            r = box.rect
+            tc = self._theme_color(box.node.color) or \
                 self._box_palette[bi % len(self._box_palette)]
-            bi += 1
-            self.box(slide, bl, bt, bw, bh, node.label, tc,
-                     sub=node.sublabel or None, fsize=bsz, ssize=bsz)
-        for label, bl, bt, bw, bh in plan["ellipses"]:
+            self.box(slide, r.left, r.top, r.width, r.height, box.node.label,
+                     tc, sub=box.node.sublabel or None, fsize=bsz, ssize=bsz)
+        for ell in plan.ellipses:
             # 省略記号スロットは固定幅／固定高（flow.py）なので上下中央に置き，
             # 隣接する矢印との重なりを避ける．
-            self.note(slide, bl, bt, bw, bh, label, bsz, tc=self.T2, bold=True,
-                      align=PP_ALIGN.CENTER, anchor=MSO_ANCHOR.MIDDLE)
+            r = ell.rect
+            self.note(slide, r.left, r.top, r.width, r.height, ell.text, bsz,
+                      tc=self.T2, bold=True, align=PP_ALIGN.CENTER,
+                      anchor=MSO_ANCHOR.MIDDLE)
         # ノード間のすき間に塗りつぶしのブロック矢印を置く（太さは box 高に比例）．
-        box_h_emu = boxes[0][4] if boxes else Inches(1.0)
+        box_h_emu = boxes[0].rect.height if boxes else Inches(1.0)
         thick = int(box_h_emu * 0.34)
-        for x1, y1, x2, y2 in plan["arrows"]:
-            self.block_arrow(slide, x1, y1, x2, y2, thick)
-        for text, bl, bt, bw, bh in plan["labels"]:
-            self.note(slide, bl, bt, bw, bh, text, bsz, tc=self.T2, bold=True,
-                      align=PP_ALIGN.CENTER)
-        for text, bl, bt, bw, bh, role in plan["captions"]:
-            # caption のみ図に付随（note_top / note_bottom はプレースホルダ側で描く）．
-            if role == "caption":
-                self.note(slide, bl, bt, bw, bh, text, bsz, tc=self.T2,
-                          align=PP_ALIGN.CENTER)
+        for arrow in plan.arrows:
+            self.block_arrow(slide, arrow.x1, arrow.y1, arrow.x2, arrow.y2,
+                             thick)
+        for lab in plan.labels:
+            r = lab.rect
+            self.note(slide, r.left, r.top, r.width, r.height, lab.text, bsz,
+                      tc=self.T2, bold=True, align=PP_ALIGN.CENTER)
+        for cap in plan.captions:
+            # 図に付くのは caption だけ（note_top / note_bottom は地の文なので
+            # 本文プレースホルダ側で描く——plan にも入っていない）．
+            r = cap.rect
+            self.note(slide, r.left, r.top, r.width, r.height, cap.text, bsz,
+                      tc=self.T2, align=PP_ALIGN.CENTER)
 
     def _table_col_widths(self, ncols, width, col_ratios):
         """表の列幅（EMU）リストを返す（均等 or 比率指定）．"""

--- a/tests/test_flow_parse.py
+++ b/tests/test_flow_parse.py
@@ -187,20 +187,33 @@ def test_the_error_shows_where_it_gave_up():
         F.parse_flow("[A] ~ここ~ [B]")
 
 
+# --------------------------------------------------------- 矩形（#71）
+
+def test_a_rect_knows_its_own_edges_and_centre():
+    """``Rect`` の端と中心．**実測値を直に書く**．
+
+    他のテストが ``a.right`` のような属性で期待値を組み立てているので，
+    ここだけは属性を使わずに数で押さえる——さもないと実装が壊れたとき
+    期待値も同じように壊れて，両辺が一致してしまう（実際にそうなった）．
+    """
+    r = F.Rect(left=100, top=200, width=30, height=41)
+
+    assert (r.left, r.top, r.width, r.height) == (100, 200, 30, 41)
+    assert (r.right, r.bottom) == (130, 241)
+    assert (r.center_x, r.center_y) == (115, 220)   # 端数は切り捨て
+
+
 # --------------------------------------------------------- 配置（#26）
-
-# 主軸方向の大きさを取り出す添字．boxes / ellipses はどちらも
-# (中身, l, t, w, h) の並びで，lr なら w，tb なら h を見る．
-_MAIN_AXIS = {"lr": 3, "tb": 4}
-
 
 def _slots(plan, direction):
     """箱と省略記号を並び順に戻し，(省略記号か, 主軸方向の大きさ) の列を返す．"""
-    axis = _MAIN_AXIS[direction]
-    pos = 1 if direction == "lr" else 2              # l / t
-    items = ([(b[pos], False, b[axis]) for b in plan["boxes"]]
-             + [(e[pos], True, e[axis]) for e in plan["ellipses"]])
-    return [(is_ellipsis, size) for _, is_ellipsis, size in sorted(items)]
+    rects = ([(b.rect, False) for b in plan.boxes]
+             + [(e.rect, True) for e in plan.ellipses])
+    if direction == "lr":
+        rects.sort(key=lambda r: r[0].left)
+        return [(is_ellipsis, r.width) for r, is_ellipsis in rects]
+    rects.sort(key=lambda r: r[0].top)
+    return [(is_ellipsis, r.height) for r, is_ellipsis in rects]
 
 
 @pytest.mark.parametrize("direction", ["lr", "tb"])
@@ -235,8 +248,29 @@ def test_it_draws_one_arrow_per_edge(direction):
         F.parse_flow(f"direction: {direction}\n[A] -> [B] -付き-> [C]"),
         0, 0, F.EMU * 8, F.EMU * 4)
 
-    assert len(plan["arrows"]) == 2
-    assert [lb[0] for lb in plan["labels"]] == ["付き"]
+    assert len(plan.arrows) == 2
+    assert [lb.text for lb in plan.labels] == ["付き"]
+
+
+@pytest.mark.parametrize("direction", ["lr", "tb"])
+def test_an_arrow_runs_between_the_two_nodes(direction):
+    """矢印は前のノードの端から次のノードの端まで（中を突き抜けない）．
+
+    lr なら右端→左端で高さは中心，tb なら下端→上端で左右は中心．
+    ここを取り違えても座標は同じ整数なので，出力を見るまで分からない．
+    """
+    plan = F.plan_flow(F.parse_flow(f"direction: {direction}\n[A] -> [B]"),
+                       0, 0, F.EMU * 8, F.EMU * 4)
+    (a, b), (arrow,) = [x.rect for x in plan.boxes], plan.arrows
+
+    # 期待値は Rect の端・中心の属性を使わずに組む（属性が壊れたとき、
+    # 期待値まで一緒に壊れて一致してしまうのを避ける）．
+    if direction == "lr":
+        assert (arrow.x1, arrow.x2) == (a.left + a.width, b.left)
+        assert arrow.y1 == arrow.y2 == a.top + a.height // 2
+    else:
+        assert (arrow.y1, arrow.y2) == (a.top + a.height, b.top)
+        assert arrow.x1 == arrow.x2 == a.left + a.width // 2
 
 
 def test_a_caption_sits_below_the_boxes():
@@ -244,11 +278,11 @@ def test_a_caption_sits_below_the_boxes():
     plan = F.plan_flow(F.parse_flow("[A] -> [B]\ncaption: 説明"),
                        0, 0, F.EMU * 8, F.EMU * 4)
 
-    (text, _left, top, _w, _h, role), = plan["captions"]
-    box_bottom = max(b[2] + b[4] for b in plan["boxes"])
+    (caption,) = plan.captions
+    box_bottom = max(b.rect.bottom for b in plan.boxes)
 
-    assert (text, role) == ("説明", "caption")
-    assert top >= box_bottom
+    assert caption.text == "説明"
+    assert caption.rect.top >= box_bottom
 
 
 def test_notes_are_not_drawn_here():
@@ -261,11 +295,11 @@ def test_notes_are_not_drawn_here():
         F.parse_flow("[A]\nnote(top): 上\nnote(bottom): 下\ncaption: 中"),
         0, 0, F.EMU * 8, F.EMU * 4)
 
-    assert [c[0] for c in plan["captions"]] == ["中"]
+    assert [c.text for c in plan.captions] == ["中"]
 
 
 def test_an_empty_flow_plans_nothing():
     """ノードが無ければ何も置かない（空の枠だけが残らないように）．"""
     plan = F.plan_flow(F.parse_flow(""), 0, 0, F.EMU * 8, F.EMU * 4)
 
-    assert all(v == [] for v in plan.values())
+    assert plan == F.FlowPlan()

--- a/tests/test_flow_parse.py
+++ b/tests/test_flow_parse.py
@@ -263,8 +263,11 @@ def test_an_arrow_runs_between_the_two_nodes(direction):
                        0, 0, F.EMU * 8, F.EMU * 4)
     (a, b), (arrow,) = [x.rect for x in plan.boxes], plan.arrows
 
-    # 期待値は Rect の端・中心の属性を使わずに組む（属性が壊れたとき、
-    # 期待値まで一緒に壊れて一致してしまうのを避ける）．
+    # 期待値は ``right`` / ``center_y`` といった**導出プロパティを経由せず**，
+    # 素の値（left / top / width / height）の算術で組む．プロパティを使うと，
+    # それが壊れたとき期待値まで同じように壊れて一致してしまう（実際そうなった）．
+    # 素の値そのものは test_a_rect_knows_its_own_edges_and_centre が実測値で
+    # 押さえているので，ここはその上に乗る．
     if direction == "lr":
         assert (arrow.x1, arrow.x2) == (a.left + a.width, b.left)
         assert arrow.y1 == arrow.y2 == a.top + a.height // 2


### PR DESCRIPTION
Resolves #71

`plan_flow` の戻り値を位置つきタプルの dict から dataclass に替える。#34（`flow.py` のトークン）と同じ問題の一段上で、今回は `render.py` にも波及する。

## 問題

```python
plan: dict[str, list] = {"boxes": [], "ellipses": [], "arrows": [], ...}
```

キーごとに要素数が 4 / 5 / 6 で、**先頭要素の意味も違う**（`FlowNode` / ラベル文字列 / 座標）。`dict[str, list]` は実質 `dict[str, Any]` なので、キーを打ち間違えても添字を取り違えても型チェッカは何も言わない。`render.py` が7か所で位置に依存し、うち1つは `boxes[0][4]` という生の添字だった。

**レイアウト側はもっと悪い形だった。** `_plan_horizontal` と `_plan_vertical` がどちらも `centers` という同じ名前のリストを作るのに、中身の意味が違う。

| | `a[0]` | `a[2]` |
|---|---|---|
| `_plan_horizontal` | 左端 | **右端** |
| `_plan_vertical` | 中心 x | **下端** |

同じ名前・同じ添字で別のものを指していた。

## 変更

`Rect` / `PlacedNode` / `PlacedText` / `PlacedArrow` / `FlowPlan` を導入した。`Rect` は端と中心を導出プロパティで持つので、`a.right` / `a.center_y` と書ける。`centers` は**すでに置いている矩形そのもの**になり、別に組み立てる必要がなくなった。

**`role` は削除した。** `plan_flow` は `"caption"` しか積まないので、`render.py` の `if role == "caption"` は**偽になりえない**。`note_top` / `note_bottom` は別経路で本文プレースホルダへ入り、plan には来ない。存在しない区別のための枠だった。

## 座標が変わらないことの確認

**構成上変わらない**——`Rect` は元のタプルと同じ式から作り、導出プロパティは元の足し算と同じ整数演算に展開される。ただし**確かめた**。

- `plan_flow` の座標を **25 プラン**（両方向 × 2 領域、省略記号・キャプション・8ノード・範囲外エッジを含む）で、正規形に落として**フィールド単位で一致**
- `example.md` を変更前後で生成し、**デッキ全体 55 図形が種類・座標・文字とも一致**

## mypy が仕事をした

書き換えの途中、`placed` という変数名を `PlacedNode` と `PlacedText` の両方のループに使い回したところ、mypy が **6件のエラー**を出した。テストは全件通り、出力も一致していたので、**実行だけでは気づけなかった**もの。名前を分けて解消（`box` / `ell` / `lab` / `cap`）。これが `dict[str, Any]` では起きなかったことそのもの。

## ミューテーション確認で分かったこと

9項目のうち **2項目が最初は生き残った**。`Rect.right` と `Rect.center_x` を壊してもテストが緑のまま。

原因は**テストが実装と同じアクセサで期待値を組んでいた**こと。

```python
assert (arrow.x1, arrow.x2) == (a.right, b.left)   # right が壊れると両辺が同じように壊れる
```

`Rect` の端と中心を**実測値で直に押さえるテスト**を足し、矢印の期待値は `left + width` のように属性を経由せず組み直した。現在は9項目すべて捕捉する。

## 検証

- `pytest` 127 passed（新規2件を含む）
- `mypy --no-incremental` 0件
- `python3 -m md2pptx.parser` の自己検証
- テストから `_MAIN_AXIS = {"lr": 3, "tb": 4}` が消えた（#71 の完了条件）。`plan["..."]` も `centers` も `boxes[0][4]` も残っていない
