### PR TITLE
feat: enforce annotated signatures everywhere but render.py

### DIFF
--- a/md2pptx/cli.py
+++ b/md2pptx/cli.py
@@ -35,7 +35,7 @@ from . import parser as md_parser  # 標準ライブラリ parser とは別物
 from . import pdf as pdf_backend
 from . import render
 from . import watch
-from .ir import Image
+from .ir import Deck, Image
 from .pdf import ENV_CONVERTER, ENV_TIMEOUT
 from .thmx2pptx import ThmxError, thmx_to_pptx
 
@@ -73,7 +73,7 @@ class BuildResult:
     sources: frozenset[str]
 
 
-def load_base(theme_path, keep_base=None):
+def load_base(theme_path: str, keep_base: str | None = None) -> tuple[str, bool]:
     """テーマ（.thmx / .pptx）を base pptx のパスへ収束させる（DESIGN.md §3.5）．
 
     Args:
@@ -113,7 +113,7 @@ def _as_path(value: object, key: str) -> str | None:
     )
 
 
-def _image_sources(deck, base_dir: str) -> list[str]:
+def _image_sources(deck: Deck, base_dir: str) -> list[str]:
     """Deck が参照する画像ファイルを列挙する（``--watch`` の監視対象）．
 
     単一カラム（``blocks``）と多カラム（``columns``）の両方を見る．解決規則は
@@ -136,7 +136,7 @@ def _image_sources(deck, base_dir: str) -> list[str]:
     return found
 
 
-def _parse_args(argv):
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
     ap = argparse.ArgumentParser(
         prog="md2pptx",
         description="Convert a Markdown deck into a themed .pptx (Phase 1).",
@@ -195,7 +195,7 @@ def _parse_args(argv):
     return ap.parse_args(argv)
 
 
-def main(argv=None):
+def main(argv: list[str] | None = None) -> int:
     """CLI のエントリポイント．成功時は終了コード 0 を返し，失敗は SystemExit で終える．
 
     想定内の失敗（thmx 変換失敗・入力ファイルの不在／権限）は
@@ -211,7 +211,7 @@ def main(argv=None):
         raise SystemExit(f"md2pptx: {e}")
 
 
-def _run(args):
+def _run(args: argparse.Namespace) -> int:
     _check_invocation(args)
     if args.watch:
         return _run_watch(args)
@@ -222,7 +222,7 @@ def _run(args):
     return 0
 
 
-def _check_invocation(args) -> None:
+def _check_invocation(args: argparse.Namespace) -> None:
     """起動時に一度だけ行う引数の検査．
 
     **watch でもここは即座に失敗させる**（打ち間違いを見張り続けても仕方がない）．
@@ -237,7 +237,7 @@ def _check_invocation(args) -> None:
         raise SystemExit("md2pptx: --pdf-output requires a path")
 
 
-def _run_watch(args) -> int:
+def _run_watch(args: argparse.Namespace) -> int:
     """`--watch`：入力とその依存を見張り，変わるたびに作り直す（止まらない）．"""
     previous: frozenset[str] = frozenset()
 
@@ -268,7 +268,8 @@ def _run_watch(args) -> int:
                      seed=[os.path.abspath(args.input)])
 
 
-def build_once(args, *, unattended: bool = False) -> BuildResult:
+def build_once(args: argparse.Namespace, *,
+               unattended: bool = False) -> BuildResult:
     """引数 1 セットぶんを 1 回ビルドする（parse → 解決 → render → 任意で PDF）．
 
     一発実行と ``--watch`` の共通部分．``saved:`` 等の表示もここで行う——標準出力と
@@ -293,7 +294,8 @@ def build_once(args, *, unattended: bool = False) -> BuildResult:
         raise BuildError(str(e), sources)
 
 
-def _build(args, sources: set[str], unattended: bool) -> BuildResult:
+def _build(args: argparse.Namespace, sources: set[str],
+           unattended: bool) -> BuildResult:
     """``build_once`` の本体．``sources`` に読んだファイルを足しながら進む．"""
     # 1) Markdown -> IR（Deck）
     try:

--- a/md2pptx/flow.py
+++ b/md2pptx/flow.py
@@ -34,7 +34,7 @@ _DIRECTIONS: tuple[Literal["lr", "tb"], ...] = ("lr", "tb")
 _NODE_KINDS: tuple[Literal["box", "ellipsis"], ...] = ("box", "ellipsis")
 
 
-def _emu(inch):
+def _emu(inch: float) -> int:
     return int(inch * EMU)
 
 
@@ -294,8 +294,8 @@ def plan_flow(flow: Flow, left: int, top: int, width: int,
     return plan
 
 
-def _plan_horizontal(plan: FlowPlan, flow, left, top, width, height,
-                     cap_reserve) -> int:
+def _plan_horizontal(plan: FlowPlan, flow: Flow, left: int, top: int,
+                     width: int, height: int, cap_reserve: int) -> int:
     """横並び（lr）に配置し，box 帯の下端 y（キャプション基準）を返す．"""
     nodes = flow.nodes
     n = len(nodes)
@@ -345,8 +345,8 @@ def _plan_horizontal(plan: FlowPlan, flow, left, top, width, height,
     return by + bh
 
 
-def _plan_vertical(plan: FlowPlan, flow, left, top, width, height,
-                   cap_reserve) -> int:
+def _plan_vertical(plan: FlowPlan, flow: Flow, left: int, top: int,
+                   width: int, height: int, cap_reserve: int) -> int:
     """縦並び（tb）に配置し，box 列の下端 y（キャプション基準）を返す．"""
     nodes = flow.nodes
     n = len(nodes)

--- a/md2pptx/ir.py
+++ b/md2pptx/ir.py
@@ -260,7 +260,7 @@ class TitleSlide:
     affiliation_deltas: list[int | None] = field(default_factory=list)
     notes: str | None = None
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         # 不変条件：affiliation_deltas は affiliation と同じ長さ（各行 1 対 1）．
         # 直接構築（テスト等）で長さがずれても None 詰め／切り詰めで揃え，
         # render 側が添字で安全に対応付けられるようにする．

--- a/md2pptx/parser.py
+++ b/md2pptx/parser.py
@@ -20,12 +20,13 @@ python-pptx には依存しない（描画は render.py の責務）．
 from __future__ import annotations
 
 import re
-from typing import Literal
+from typing import Any, Literal
 
 import yaml
 
 from .ir import (
-    Align, Crop, Deck, Flow, Image, Length, Line, Slide, Table, TitleSlide,
+    Align, Block, Crop, Deck, Flow, Image, Length, Line, Slide, Table,
+    TitleSlide,
 )
 from .flow import parse_flow as _parse_flow
 
@@ -216,7 +217,7 @@ def _build_title_slide(meta: dict) -> TitleSlide | None:
     )
 
 
-def _split_size_opt(value) -> tuple[int | None, str | None]:
+def _split_size_opt(value: object) -> tuple[int | None, str | None]:
     """front matter 値（None 可）の先頭相対サイズトークンを剥がして (段数, 文字列) を返す．
 
     None はそのまま (None, None)．トークン判定は文字列のみ対象とし，数値等
@@ -254,7 +255,7 @@ def _parse_body(body: str, body_offset: int = 0,
             current = Slide()
         return current
 
-    def add_block(b) -> None:
+    def add_block(b: Block) -> None:
         """ブロックを現在のカラム（多カラム時）または blocks へ追加する．"""
         s = ensure_slide()
         (s.columns[-1] if s.columns else s.blocks).append(b)
@@ -642,7 +643,7 @@ def _parse_content_line(raw: str) -> Line | None:
     if not s:
         return None
 
-    def _mk(text, **kw):
+    def _mk(text: str, **kw: Any) -> Line | None:
         """本文が空（マーカー／サイズトークンだけの行）なら Line を作らず None．
         マーカー除去後に空の行を IR に入れない（先頭の空行チェックと整合）．
 
@@ -748,7 +749,7 @@ affiliation:
 → 表・フロー図が Line 決め打ちで落ちないことの確認を兼ねる
 """
 
-    def _dump_block(b) -> str:
+    def _dump_block(b: Block) -> str:
         """ブロックを 1 行で表す．blocks は Line 以外も持つので型で分岐する．"""
         if isinstance(b, Line):
             return (f"Line(kind={b.kind!r} level={b.level} "

--- a/md2pptx/thmx2pptx.py
+++ b/md2pptx/thmx2pptx.py
@@ -159,10 +159,12 @@ def thmx_to_pptx(thmx_path: str, out_path: str | None = None) -> str:
         raise ThmxError(f"thmx not found: {thmx_path}")
 
     # out_path を内部で用意した場合のみ，失敗時に後始末する（呼び出し側指定は触らない）．
-    # 分岐の条件を created_out ではなく out_path そのものにしているのは，
-    # 「ここから先は None ではない」を変数ではなくコードの形で示すため
-    # （created_out を条件にすると，読む側も型チェッカも 2 つの変数を
-    # 突き合わせないと分からない）．
+    # created_out はそのための記録で，**下の except まで生き残る**——そこでは
+    # out_path はどちらの経路でも None ではないので，「自分で作ったのか」は
+    # out_path からは復元できない．
+    # 一方，直下の分岐は out_path 自身を条件にする．「ここから先は None ではない」
+    # をコードの形で示すためで，created_out を条件にすると読む側も型チェッカも
+    # 2 つの変数を突き合わせないと分からない（mypy が 4 箇所で落ちた）．
     created_out = out_path is None
     if out_path is None:
         fd, out_path = tempfile.mkstemp(suffix=".pptx", prefix="md2pptx-base-")

--- a/md2pptx/thmx2pptx.py
+++ b/md2pptx/thmx2pptx.py
@@ -46,7 +46,7 @@ class ThmxError(Exception):
     """thmx 変換時のエラー．"""
 
 
-def _count_layouts(extract_dir):
+def _count_layouts(extract_dir: str) -> int:
     """展開済みディレクトリ内の slideLayout 数を数える（テーマ差し替えに追従）．"""
     layout_dir = os.path.join(extract_dir, "theme", "slideLayouts")
     if not os.path.isdir(layout_dir):
@@ -57,7 +57,7 @@ def _count_layouts(extract_dir):
     ])
 
 
-def _check_full_theme(extract_dir):
+def _check_full_theme(extract_dir: str) -> int:
     """フルテーマ型（マスター＋レイアウト同梱）であることを検証する．
 
     色・フォントのみの簡易テーマはレイアウトを持たず，スライドの土台にできない．
@@ -74,7 +74,7 @@ def _check_full_theme(extract_dir):
     return n
 
 
-def _rewrite_content_types(extract_dir, nlayout):
+def _rewrite_content_types(extract_dir: str, nlayout: int) -> None:
     """[Content_Types].xml を pptx 向けに書き換える（DESIGN.md §3.2 の 3 点）．"""
     path = os.path.join(extract_dir, "[Content_Types].xml")
     ct = open(path, encoding="utf-8").read()
@@ -110,7 +110,7 @@ def _rewrite_content_types(extract_dir, nlayout):
     open(path, "w", encoding="utf-8").write(ct)
 
 
-def _rewrite_root_rels(extract_dir):
+def _rewrite_root_rels(extract_dir: str) -> None:
     """_rels/.rels の officeDocument リレーションシップを presentation 本体へ向ける．
 
     標準的な thmx では officeDocument は ``theme/theme/themeManager.xml`` を指す
@@ -121,7 +121,7 @@ def _rewrite_root_rels(extract_dir):
     path = os.path.join(extract_dir, "_rels", ".rels")
     s = open(path, encoding="utf-8").read()
 
-    def _retarget(m):
+    def _retarget(m: re.Match[str]) -> str:
         return re.sub(r'Target="[^"]*"', 'Target="ppt/presentation.xml"', m.group(0))
 
     s = re.sub(
@@ -135,7 +135,7 @@ def _rewrite_root_rels(extract_dir):
     open(path, "w", encoding="utf-8").write(s)
 
 
-def _repack(extract_dir, out_path):
+def _repack(extract_dir: str, out_path: str) -> None:
     """展開ディレクトリを pptx（ZIP）として書き出す．[Content_Types].xml を先頭に置く．"""
     if os.path.exists(out_path):
         os.remove(out_path)
@@ -150,7 +150,7 @@ def _repack(extract_dir, out_path):
                 z.write(full, arc)
 
 
-def thmx_to_pptx(thmx_path, out_path=None):
+def thmx_to_pptx(thmx_path: str, out_path: str | None = None) -> str:
     """thmx を base pptx に変換し，出力先パスを返す．
 
     out_path 省略時は一時ファイル（``*.pptx``）に書き出す（呼び出し側で破棄する）．
@@ -159,8 +159,12 @@ def thmx_to_pptx(thmx_path, out_path=None):
         raise ThmxError(f"thmx not found: {thmx_path}")
 
     # out_path を内部で用意した場合のみ，失敗時に後始末する（呼び出し側指定は触らない）．
+    # 分岐の条件を created_out ではなく out_path そのものにしているのは，
+    # 「ここから先は None ではない」を変数ではなくコードの形で示すため
+    # （created_out を条件にすると，読む側も型チェッカも 2 つの変数を
+    # 突き合わせないと分からない）．
     created_out = out_path is None
-    if created_out:
+    if out_path is None:
         fd, out_path = tempfile.mkstemp(suffix=".pptx", prefix="md2pptx-base-")
         os.close(fd)
 
@@ -191,7 +195,7 @@ def thmx_to_pptx(thmx_path, out_path=None):
     return out_path
 
 
-def main(argv=None):
+def main(argv: list[str] | None = None) -> None:
     import argparse
 
     ap = argparse.ArgumentParser(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,3 +49,24 @@ warn_unused_ignores = true
 warn_redundant_casts = true
 # 未注釈の関数の中身も見る（描画ヘルパーは注釈が薄いので取りこぼしを減らす）．
 check_untyped_defs = true
+
+# シグネチャの注釈は、済んだモジュールから順に強制していく（Issue #35）。
+# 全モジュールが並んだら、この overrides を消して上の [tool.mypy] に
+# disallow_untyped_defs = true を 1 行置いて終わり。
+#
+# 残りは render.py の 65 関数。うち 31 が python-pptx のオブジェクトを受け取り、
+# **render.py は ir から Slide / Line / Table を import している**——python-pptx にも
+# 同名の型があるので、別名の付け方を決めてからでないと `slide: Slide` が
+# IR のほうに解決される。ここだけ別の判断が要るので分けてある。
+[[tool.mypy.overrides]]
+module = [
+    "md2pptx.cli",
+    "md2pptx.flow",
+    "md2pptx.ir",
+    "md2pptx.parser",
+    "md2pptx.pdf",
+    "md2pptx.thmx2pptx",
+    "md2pptx.watch",
+    "md2pptx.workdir",
+]
+disallow_untyped_defs = true

--- a/tests/test_thmx_out_path.py
+++ b/tests/test_thmx_out_path.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""変換に失敗したとき何を消して何を残すかを固定するテスト（Issue #35 の途中で追加）．
+
+``thmx_to_pptx`` は出力先を省略できる．省略されたら一時ファイルを自分で作るので，
+**失敗したらそれは自分で片付ける**——空の pptx が ``/tmp`` に溜まっていくのは
+呼び出し側からは見えない．逆に**出力先を渡されたときは触らない**．そこにある
+ファイルは呼び出し側のもので、変換が失敗したからといって消してよい理由がない．
+
+この 2 つを分けているのが ``created_out`` で、#35 で注釈を入れる際に
+「``out_path`` はこの行以降 None ではない」という不変条件が変数の中にしか
+無いことが分かり、分岐の条件を ``out_path`` 自身へ変えた．振る舞いは同じだが、
+**同じであること自体が誰にも確かめられていなかった**のでここで固定する．
+
+壊れた zip を入力にするのは、``tempfile`` を作る行を通り抜けてから失敗させる
+ためで、そうしないと片付けの経路に入らない（入力が無い場合はその手前で返る）．
+"""
+from __future__ import annotations
+
+import glob
+import os
+import tempfile
+
+import pytest
+
+from md2pptx.thmx2pptx import ThmxError, thmx_to_pptx
+
+
+@pytest.fixture
+def broken_thmx(tmp_path):
+    """zip として開けないファイル．展開の直前まで進んでから失敗する．"""
+    path = tmp_path / "broken.thmx"
+    path.write_text("これは zip ではない")
+    return str(path)
+
+
+def _stray_temps():
+    return set(glob.glob(os.path.join(tempfile.gettempdir(),
+                                      "md2pptx-base-*.pptx")))
+
+
+def test_it_cleans_up_the_temp_file_it_made_itself(broken_thmx):
+    """出力先を省略した場合，失敗しても一時ファイルを残さない．"""
+    before = _stray_temps()
+
+    with pytest.raises(ThmxError, match="not a valid thmx"):
+        thmx_to_pptx(broken_thmx)
+
+    assert _stray_temps() - before == set()
+
+
+def test_it_does_not_touch_a_file_the_caller_named(broken_thmx, tmp_path):
+    """出力先を渡された場合，失敗してもそのファイルには手を出さない．
+
+    消すと，前回の変換結果を出力先にしていた人が**失敗しただけで成果物を失う**．
+    """
+    out = tmp_path / "mine.pptx"
+    out.write_text("呼び出し側が用意した中身")
+
+    with pytest.raises(ThmxError, match="not a valid thmx"):
+        thmx_to_pptx(broken_thmx, str(out))
+
+    assert out.read_text() == "呼び出し側が用意した中身"
+
+
+def test_a_missing_input_fails_before_making_anything(tmp_path):
+    """入力が無ければ一時ファイルを作る前に返る（作ってから消すより素直）．"""
+    before = _stray_temps()
+
+    with pytest.raises(ThmxError, match="thmx not found"):
+        thmx_to_pptx(str(tmp_path / "nope.thmx"))
+
+    assert _stray_temps() - before == set()

--- a/tests/test_thmx_out_path.py
+++ b/tests/test_thmx_out_path.py
@@ -17,13 +17,22 @@
 """
 from __future__ import annotations
 
-import glob
-import os
 import tempfile
 
 import pytest
 
 from md2pptx.thmx2pptx import ThmxError, thmx_to_pptx
+
+
+@pytest.fixture(autouse=True)
+def own_tempdir(tmp_path, monkeypatch):
+    """一時ファイルの行き先を，このテスト専用の空ディレクトリへ向ける．
+
+    共有の ``/tmp`` を見ると，**他のプロセスが作った同名のファイルを数えてしまう**
+    ——並行実行やビルドの同時進行で、残っていないのに残ったと言う（逆もある）．
+    行き先ごと閉じ込めれば、「このディレクトリが空か」を見るだけで済む．
+    """
+    monkeypatch.setattr(tempfile, "tempdir", str(tmp_path))
 
 
 @pytest.fixture
@@ -34,19 +43,16 @@ def broken_thmx(tmp_path):
     return str(path)
 
 
-def _stray_temps():
-    return set(glob.glob(os.path.join(tempfile.gettempdir(),
-                                      "md2pptx-base-*.pptx")))
+def _temps(tmp_path):
+    return sorted(p.name for p in tmp_path.glob("md2pptx-base-*.pptx"))
 
 
-def test_it_cleans_up_the_temp_file_it_made_itself(broken_thmx):
+def test_it_cleans_up_the_temp_file_it_made_itself(broken_thmx, tmp_path):
     """出力先を省略した場合，失敗しても一時ファイルを残さない．"""
-    before = _stray_temps()
-
     with pytest.raises(ThmxError, match="not a valid thmx"):
         thmx_to_pptx(broken_thmx)
 
-    assert _stray_temps() - before == set()
+    assert _temps(tmp_path) == []
 
 
 def test_it_does_not_touch_a_file_the_caller_named(broken_thmx, tmp_path):
@@ -65,9 +71,7 @@ def test_it_does_not_touch_a_file_the_caller_named(broken_thmx, tmp_path):
 
 def test_a_missing_input_fails_before_making_anything(tmp_path):
     """入力が無ければ一時ファイルを作る前に返る（作ってから消すより素直）．"""
-    before = _stray_temps()
-
     with pytest.raises(ThmxError, match="thmx not found"):
         thmx_to_pptx(str(tmp_path / "nope.thmx"))
 
-    assert _stray_temps() - before == set()
+    assert _temps(tmp_path) == []


### PR DESCRIPTION
Refs #35（**close しません** — `render.py` が残るため。理由は下記）

Issue #35 の計画どおりモジュール単位で締める。`render.py` 以外の5モジュール（25関数）に注釈を入れ、`[[tool.mypy.overrides]]` で `disallow_untyped_defs` を有効にした。

## 状態

| モジュール | 未注釈だった関数 | いま |
|---|---:|---|
| `ir.py` / `flow.py` / `parser.py` / `cli.py` / `thmx2pptx.py` | 25 | **強制** |
| `pdf.py` / `watch.py` / `workdir.py` | 0 | **強制**（もともと注釈済み） |
| `render.py` | 65 | `check_untyped_defs` のまま |

設定が効いていることは確かめてあります——`ir.__post_init__` の `-> None` を外すと mypy が落ちます。

## `render.py` を外した理由

時間の都合ではありません。65関数のうち **31が python-pptx のオブジェクトを受け取り**、そして

```python
from .ir import (
    Block, Deck, Flow, Image, Line, ObjectBlock, Slide, Table, TitleSlide,
)
```

**python-pptx にも `Slide` / `Line` / `Table` があります。** 代表5関数で試したところ、`slide: Slide` は IR の dataclass に解決され `"Slide" has no attribute "shapes"` になりました。別名の付け方は31関数すべてに関わるので、**ついでに決める種類の判断ではありません**。

## 注釈だけで終わらなかった2件

### `thmx_to_pptx` の不変条件が変数の中にしかなかった

```python
created_out = out_path is None
if created_out:
    fd, out_path = tempfile.mkstemp(...)
```

以降 `out_path` が `None` でないことを **`created_out` という別の bool が覚えている**状態で、読む側も型チェッカも2つの変数を突き合わせないと分かりません。mypy が4か所で落ちました。

条件を `if out_path is None:` に変え、**不変条件が成り立つ場所で書く**ようにしました。振る舞いは同一です。

### `_split_size_opt` の引数は `str` ではなく `object`

`meta.get(...)` で呼ばれ、front matter は YAML なので**何でも来ます**。本体はすでに `isinstance(value, str)` で分けており、注釈がその事実に追いついていませんでした。

## テストを1つ足しました

`thmx_to_pptx` の**片付けの契約に一切テストがありません**でした。自分で作った一時ファイルは消し、呼び出し側が名指ししたファイルには触らない——後者を消すと、**失敗しただけで前回の成果物を失います**。

制御フローを触った以上、同じであることを確かめる手段が要ります。3件足し、条件の変異2通りとも落ちることを確認しました。

## 検証

- `mypy --no-incremental` 0件（新しい設定で）
- `pytest` 130 passed（新規3件を含む）
- **`example.md` の55図形が変更前と一致**
- `python3 -m md2pptx.parser` / `thmx2pptx` の CLI

## `Resolves` にしていない理由

`render.py` の65関数が残っており、Issue の完了条件（`[[tool.mypy.overrides]]` を消してトップレベルに1行置く）に届いていません。close は最後の PR で行うべきと判断しました。
