### PR TITLE
refactor: remove four helpers nothing calls

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,9 +18,15 @@ md2pptx — Markdown と PowerPoint テーマ（thmx / pptx）から発表スラ
 render の責務）。`ir.py` がパーサとレンダラの契約。新しい記法を足すときは「parser が
 IR を作る／render が IR を描く」の分離を保つ。
 
-描画ヘルパー（`box`/`arrow`/`set_autonum`/`no_bullet`/`fit_body` 等）は、
+描画ヘルパー（`box`/`block_arrow`/`set_autonum`/`no_bullet`/`fit_body` 等）は、
 本ツールの土台になった手書きスクリプト（個人デッキ生成用、リポジトリには含めない）から
-`render.py` へ移植したもの。
+`render.py` へ移植したもの。**移植しても IR 経由の描画では通らないものがある。**
+`arrow`/`add_bullets`/`enum_items`/`content_slide` は呼び出し元が無いまま残り、
+Issue #75 で削除した。そのうち `arrow` は、
+docstring が「直線コネクタ」と書きながら実際には ELBOW（かぎ線）を渡していた。
+**呼ばれないコードは誤りを抱えたまま検証されない**——直すも消すも、
+出力を見て判断できないからそのままになる。移植したものを足すときは、
+呼び出し元まで繋いでから入れる。
 
 ## コマンド
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -76,9 +76,10 @@ pptx」をメモリ上または一時ファイルに用意する。ステージ3
 `[project.scripts]` が `md2pptx = "md2pptx.cli:main"` としてコンソールスクリプトを生成する。
 モジュール間は相対 import（`from .ir import …`）で結線する。
 
-`参照スクリプト` のヘルパー（`content_slide`, `box`, `arrow`, `note`, `set_autonum`,
-`no_bullet`, `fit_body`, `enum_items`, `add_slide_number` 等）は **`render.py` へ移植**し、
-IR を受け取って描画する純粋関数群として整理する。
+`参照スクリプト` のヘルパー（`box`, `note`, `set_autonum`, `no_bullet`, `fit_body`,
+`add_slide_number` 等）は **`render.py` へ移植**し、IR を受け取って描画する純粋関数群
+として整理する。移植したうち IR 経由の描画では通らなくなった 4 つ
+（`arrow` / `add_bullets` / `enum_items` / `content_slide`）は削除した（Issue #75）。
 
 ## 3. thmx → base pptx 変換（ステージ0）
 
@@ -338,7 +339,7 @@ affiliation:
 
 | 書き方 | 解釈 | 対応する現行処理 |
 |---|---|---|
-| `- テキスト` / `* テキスト` | 通常箇条書き（テーマ既定の bullet） | `add_bullets` |
+| `- テキスト` / `* テキスト` | 通常箇条書き（テーマ既定の bullet） | `_fill_lines`（テーマ既定のまま） |
 | `1. テキスト`（連番） | 自動採番 `arabicPeriod`（1. 2. 3.） | `set_autonum("arabicPeriod")` |
 | `①` `②` … で始まる行 | 自動採番 `circleNumDbPlain`（丸数字）。番号文字は除去 | `set_autonum("circleNumDbPlain")` |
 | `(1)` `(2)` … で始まる行 | 自動採番 `arabicParenBoth`（丸括弧 (1) (2)） | `set_autonum` 派生 |
@@ -354,7 +355,7 @@ affiliation:
 各行はマーカー直後・本文直前に相対サイズトークン `{+1}` / `{-2}` を置ける（5.8）。
 例: `- {+1} 強調`、`① {+1} 大きい採番`、`→ {-1} 小さい結論`。
 
-#### 「見出し＋説明」（`enum_items` 相当）
+#### 「見出し＋説明」（採番＋ネスト bullet）
 
 採番行の直下に通常箇条書きをネストすると、見出し=採番
 level0／説明=bullet level1 として描画する。
@@ -403,7 +404,7 @@ Markdown 標準のテーブル記法。1行目をヘッダとしてアクセン�
 ### 5.5 図 DSL（` ```flow ` ブロック）
 
 box / arrow による横並びフロー図を簡潔に書く独自 DSL。`参照スクリプト` の
-`box` / `arrow` / `note` の組合せを宣言的に表現する。
+`box` / 矢印 / `note` の組合せを宣言的に表現する。
 
 ````markdown
 ```flow
@@ -440,7 +441,7 @@ note(bottom): → テーマを差し替えるだけで見た目が一新でき�
 - `flow.py` は python-pptx 非依存の純モジュール：`parse_flow(text)→ir.Flow`（`direction`/
   ノード/エッジ/`caption`/`note_top`/`note_bottom`）と、座標プランを返す
   `plan_flow(flow, left, top, width, height)`（EMU 計算のみ）の2段に分離。
-- 描画は `render.py` の `box`/`arrow`/`note`（`参照スクリプト` から移植）が担い、
+- 描画は `render.py` の `box`/`block_arrow`/`note`（`参照スクリプト` から移植）が担い、
   `render_flow` が `plan_flow` のプランを描く。配色は `T2→A6→A6→GOLD→A2` を順に自動割当、
   `{accent6}` 等で個別上書き。
 - フロー図は **Phase 2の座標スタックに `flow` セグメントとして統合**。
@@ -669,11 +670,11 @@ notes slide（発表者ビュー・ノート印刷で見えるテキスト）に
 - ステージ0の base pptx を開き、
   `SW/SH`・レイアウト・テーマ色エイリアス（`A2/A6/T2/GOLD/BG/TX`）を初期化。
 - IR の各 `Slide` を走査し、`blocks` の型に応じて描画:
-  - `Line` 列 → `content_slide` 系（`add_bullets` + マーカーに応じた
-    `set_autonum`/`no_bullet`）。
+  - `Line` 列 → 本文プレースホルダへ `_fill_lines`／`_append_lines` で流し込み、
+    マーカーに応じて `set_autonum`/`no_bullet` を適用（`bullet` はテーマ既定のまま）。
   - `Table` → `add_table`（ヘッダ着色）。テキストと共存する場合は本文に導入・結論、
     表は座標配置。
-  - `Flow` → `flow.py` のレイアウタで `box`/`arrow`/`note` を配置。
+  - `Flow` → `flow.py` のレイアウタで `box`/`block_arrow`/`note` を配置。
 - `default_autofit` が真なら本文プレースホルダに `fit_body`。`@autofit:` 指定があれば
   scale 焼き込み。
 - タイトル以外のスライドに `add_slide_number`。
@@ -883,10 +884,10 @@ md2pptx input.md --theme OfficeTheme.pptx -o out.pptx
 | 導入文＋表＋結論 | 段落＋表＋`→` | ◎ |
 | 丸数字採番（色 tx1） | `①`＋`@autonum-color: tx1` | ◎ |
 | 一部行のみ丸数字採番（黒） | `①` 混在＋`@autonum-color: tx1` | ◎ |
-| enum_items（見出し＋説明） | `1.`＋ネスト `-` | ◎ |
+| 見出し＋説明 | `1.`＋ネスト `-` | ◎ |
 | 全行採番＋結論 no_bullet | `1.` 連番＋`→` | ◎ |
 | 本文縮小 | `@autofit: 90` | ◎ |
-| box/arrow/note 図 | ` ```flow ` | ◎（矢印は box 高に比例した太さ） |
+| box/矢印/note 図 | ` ```flow ` | ◎（矢印は box 高に比例した太さ） |
 | 結論行 no_bullet | `→`（記号なし行） | ◎ |
 | 多段タイトルの明示改行 | `<br>` | ◎ |
 

--- a/md2pptx/ir.py
+++ b/md2pptx/ir.py
@@ -29,7 +29,7 @@ class Line:
         text: 段落の表示テキスト（行頭マーカー記号は除去済み）．
         level: 箇条書きの深さ．0 が最上位，2 スペースのインデントごとに +1．
         kind: 段落種別．
-            - "bullet"  : テーマ既定の箇条書き記号（add_bullets 相当）．
+            - "bullet"  : テーマ既定の箇条書き記号（記号は指定せず任せる）．
             - "autonum" : 自動採番（set_autonum 相当）．num_style で形式を指定．
             - "plain"   : 行頭記号なし（no_bullet 相当．結論・補足行など）．
             取りうる値は注釈（Literal）が正．

--- a/md2pptx/render.py
+++ b/md2pptx/render.py
@@ -8,9 +8,10 @@
 テーマのアクセント色を参照する）．
 
 ``参照スクリプト`` のモジュール大域に依存したヘルパ群（no_bullet /
-add_slide_number / add_bullets / set_autonum / enum_items / fit_body /
-content_slide）を Renderer のメソッドへ移植し，self.prs / self.layouts /
-テーマ色エイリアスから状態を解決する（DESIGN.md §6）．
+add_slide_number / set_autonum / fit_body / box / note / block_arrow 等）を
+Renderer のメソッドへ移植し，self.prs / self.layouts / テーマ色エイリアスから
+状態を解決する（DESIGN.md §6）．移植したうちパイプラインが通らなくなった
+4 つ（arrow / add_bullets / enum_items / content_slide）は削除した（Issue #75）．
 
 使い方::
 
@@ -33,7 +34,7 @@ from typing import TYPE_CHECKING, Any, Callable
 from pptx import Presentation
 from pptx.enum.text import MSO_AUTO_SIZE, MSO_ANCHOR, PP_ALIGN
 from pptx.enum.dml import MSO_THEME_COLOR
-from pptx.enum.shapes import MSO_CONNECTOR, MSO_SHAPE
+from pptx.enum.shapes import MSO_SHAPE
 from pptx.oxml.ns import qn
 from pptx.util import Emu, Inches, Pt
 # python-pptx の Slide は ir.Slide と名前がぶつかる．**外来のほうに印を付ける**
@@ -43,7 +44,6 @@ from pptx.util import Emu, Inches, Pt
 # 注釈にはクラスのほうが要る．
 from pptx.presentation import Presentation as PptxPresentation
 from pptx.shapes.autoshape import Shape
-from pptx.shapes.connector import Connector
 from pptx.shapes.graphfrm import GraphicFrame
 from pptx.shapes.picture import Picture
 from pptx.shapes.placeholder import SlidePlaceholder
@@ -156,7 +156,7 @@ class Renderer:
         self.SH = self.prs.slide_height
 
         # テーマのアクセント色（図形用）．テキスト色・フォントはテーマ任せ．
-        # Phase 1 では box/arrow/note/table（Phase 2/3）が使うため保持のみ．
+        # Phase 1 では box/block_arrow/note/table（Phase 2/3）が使うため保持のみ．
         self.A2 = MSO_THEME_COLOR.ACCENT_2       # 緑
         self.A6 = MSO_THEME_COLOR.ACCENT_6       # 緑（濃）
         self.T2 = MSO_THEME_COLOR.TEXT_2         # 緑系テキスト
@@ -218,16 +218,6 @@ class Renderer:
                 slide.shapes._spTree.append(copy.deepcopy(lph._element))
                 return
 
-    def add_bullets(self, tf: TextFrame,
-                    items: list[tuple[int, str]]) -> None:
-        """(level, text) の列を本文 text_frame に箇条書きとして流し込む．"""
-        first = True
-        for lvl, txt in items:
-            p = tf.paragraphs[0] if first else tf.add_paragraph()
-            first = False
-            p.level = lvl
-            p.text = txt
-
     def set_autonum(self, p: _Paragraph, fmt: str = "arabicPeriod",
                     color: str | None = None) -> None:
         """段落の行頭記号を自動採番（1. 2. 3. …）に切り替える（enumerate 相当）．
@@ -249,20 +239,6 @@ class Renderer:
                 break
         else:
             pPr.append(bu)
-
-    def enum_items(self, tf: TextFrame,
-                   items: list[tuple[str, str]]) -> None:
-        """(見出し, 説明) を，見出し=自動採番(level0)・説明=通常箇条書き(level1) で並べる．"""
-        first = True
-        for head, desc in items:
-            p = tf.paragraphs[0] if first else tf.add_paragraph()
-            first = False
-            p.level = 0
-            p.text = head
-            self.set_autonum(p)
-            d = tf.add_paragraph()
-            d.level = 1
-            d.text = desc
 
     def fit_body(self, tf: TextFrame, scale: float | None = None) -> None:
         """本文プレースホルダに自動調整（normAutofit）を設定する．
@@ -426,22 +402,6 @@ class Renderer:
                 return sz
         return levels[-1]
 
-    def content_slide(self, title: str,
-                      items: list[tuple[int, str]]) -> PptxSlide:
-        """タイトル＋箇条書きの基本スライドを 1 枚追加して返す．"""
-        s = self.prs.slides.add_slide(self.L1)
-        s.shapes.title.text = title
-        body = self._body_placeholder(s)
-        if body is None:
-            # 本文枠が無いテーマ．止めずに捨てたものを言う（Issue #67 と同じ扱い）．
-            self._warn_no_body([Line(text=txt) for _lvl, txt in items])
-            self.add_slide_number(s)
-            return s
-        self.add_bullets(body.text_frame, items)
-        self.fit_body(body.text_frame)
-        self.add_slide_number(s)
-        return s
-
     # --------------------------------------------------------- title slide
     def render_title_slide(self, ts: TitleSlide) -> PptxSlide:
         """タイトルスライドを 1 枚目として追加する（番号は付けない）．
@@ -601,22 +561,6 @@ class Renderer:
                 if ssize is not None:
                     r.font.size = Pt(ssize)
         return shp
-
-    def arrow(self, slide: PptxSlide, x1: int, y1: int, x2: int, y2: int,
-              w: float = 2.0) -> Connector:
-        """矢印（直線コネクタ＋三角の矢じり）を描く．"""
-        # 渡していた 2 は **ELBOW（かぎ線）** で、docstring の「直線」と食い違う．
-        # このメソッドは現在どこからも呼ばれておらず（図の矢印は block_arrow が
-        # 描く）、どちらが意図だったか確かめる手段がないので，注釈を入れるにあたり
-        # **動きを変えないほう**を採った．直すなら別途（Issue #35 の作業中に発見）．
-        cn = slide.shapes.add_connector(
-            MSO_CONNECTOR.ELBOW, Emu(x1), Emu(y1), Emu(x2), Emu(y2))
-        cn.line.color.theme_color = self.TX
-        cn.line.width = Pt(w)
-        le = cn.line._get_or_add_ln()
-        le.append(le.makeelement(
-            qn("a:tailEnd"), {"type": "triangle", "w": "med", "len": "med"}))
-        return cn
 
     def block_arrow(self, slide: PptxSlide, x1: int, y1: int, x2: int, y2: int,
                     thickness: int,


### PR DESCRIPTION
Resolves #75

`render.py` から到達不能な4メソッドを削除する。Issue の方針1（削除）。

| メソッド | 呼び出し元 |
|---|---|
| `arrow` | 無し |
| `content_slide` | 無し |
| `enum_items` | 無し |
| `add_bullets` | `content_slide` のみ（＝実質到達不能） |

いずれも本ツールの土台になった手書きスクリプトからの移植で、それを置き換えた IR 経由の描画は `render_slide` / `_render_stacked_into` を通る。

## 残しておく費用は無料ではなかった

`arrow` は `add_connector` に **`2` = ELBOW（かぎ線）** を渡しながら、docstring は「直線コネクタ」と書いていた。**誰も描画しないので誰も矛盾しない**——#35 で注釈を入れて呼び出しを型付けするまで、この食い違いは誰の目にも触れなかった。

到達不能なコードの費用はこれで、**単に使われていないのではなく、検証されない**。テストも出力も、どちらが間違いなのか教えてくれない。

## 文書にも同じことが起きていた

DESIGN.md §6 は `Line` 列の描画をこう説明していた。

> `Line` 列 → `content_slide` 系（`add_bullets` + マーカーに応じた `set_autonum`/`no_bullet`）

**この2つは動かない。** 実際に通るのは `_fill_lines` / `_append_lines` で、`bullet` はテーマ既定のまま何もしない。**指し先が検証されない文章も、同じように検証されない。**

付録の「box/arrow/note 図」も同様で、矢印を描くのは `block_arrow`。

直した箇所:

| 箇所 | 変更 |
|---|---|
| §2 | 移植の記録は残し、**4つを後に削除したことを追記** |
| §5.3 の表「対応する現行処理」 | `add_bullets` → `_fill_lines`（テーマ既定のまま） |
| §5.x 見出し | 「（`enum_items` 相当）」 → 「（採番＋ネスト bullet）」 |
| §6 | `content_slide` 系 → `_fill_lines`／`_append_lines` |
| §6 / 付録 | `arrow` → `block_arrow` |
| 付録の表 | 「enum_items（見出し＋説明）」 → 「見出し＋説明」 |
| `ir.py` | 「`add_bullets` 相当」 → 「記号は指定せず任せる」 |
| `CLAUDE.md` | 移植ヘルパーの記述を更新し、**この経験を規約として残した** |

DSL の概念語としての「box / arrow」（§1・§5.5・`ir.Flow` の docstring）はそのまま。図が描くものの名前であって、メソッド名ではない。

## 副次的に

`MSO_CONNECTOR` と `Connector` の import が不要になった（`arrow` だけが使っていた）。未使用 import が他に残っていないことも確認済み。

`Renderer` の公開メソッドは以下になる。

```
add_slide_number, block_arrow, box, fit_body, no_bullet, note, render,
render_flow, render_image, render_slide, render_table, render_title_slide,
save, set_autonum
```

README は `md2pptx` コマンドと `build()` のみ案内しており、`Renderer` の直接利用は案内していない。

## 検証

- **`example.md` の55図形が種類・座標・文字とも一致**、発表者ノートも一致
- `pytest` 134 passed
- `mypy --no-incremental` 0件
- `python3 -m md2pptx.parser` の自己検証
- 消えた4名への参照がリポジトリ内に残っていないこと（削除を記録している2行を除く）
