### PR TITLE
chore: release 1.0.0

### DIFF
--- a/md2pptx/__init__.py
+++ b/md2pptx/__init__.py
@@ -5,6 +5,6 @@
 使う場合は parser.parse_file() で Deck を得て render.build() で描画できる．
 """
 
-__version__ = "0.9.1"
+__version__ = "1.0.0"
 
 __all__ = ["__version__"]


### PR DESCRIPTION
## 概要

`__version__` を 0.9.1 から **1.0.0** へ上げます。

0.9.1 は #26 で設定したもので、以降**37コミット**が入っています（feat 11・fix 8・docs 10・refactor 5、うち破壊的変更2件）。バージョンの情報源は `md2pptx/__init__.py` の1箇所だけで、`pyproject.toml` は `dynamic` で参照しています。

## 1.0 とする理由

記法が固まったことです。#82 で表紙をフロントマターから本文へ移し終え、**同じことを言う方法が1つになりました**。

- スライドは見出しで分ける（`#` / `##` / `---`、表紙はレイアウト番号で指定）
- 大きさは相対段数で指定する（`{±n}`。絶対 pt は持たない）
- 見た目はテーマが決める（色もフォントもコードに持たない）

これまでは表紙だけが例外で、「文書のメタデータ」の名前を持つ YAML キーに描画指示（`<br>` や `{±n}`）を書かせていました。記法が二重にあるので処理も二重になり、`<br>` を片方だけ通し忘れる取りこぼし（#79）まで起きています。

そして**旧記法は警告付きで動き続けます**。これは互換性の約束であり、約束をするために 1.0 があります。

## 0.9.1 からの主な変更

**記法**

- `<br>` を本文行でも使えるように（#28）／セグメントごとに `{±n}` を置けるように（#88）
- マーカーだけの行が空段落になる（#86）
- 表紙を本文記法で書けるようにし、フロントマターの4項目を非推奨に（#89）
- 相対サイズの基点を、実際に描かれる枠の既定へ統一（#84）
- run に言語を付けて日本語の禁則処理を効かせる（#80）

**PDF と watch**

- pptx の後に PDF を生成（#39 系）。macOS では実 PowerPoint を裏で使う
- `--pdf` をフラグと `--pdf-output PATH` に分離（**破壊的**。#43）
- `--watch` で保存のたびに作り直す
- 出力 pptx / PDF を作業ディレクトリ経由で差し替える（壊れた中間状態を見せない）

**基盤**

- Python 3.11 以上を要求（**破壊的**。#37）
- mypy を CI に入れ、全シグネチャに注釈を必須化（#73 / #74）

## 確認

- `md2pptx --version` → `md2pptx 1.0.0`、`import md2pptx; md2pptx.__version__` も 1.0.0（`pyproject.toml` の `dynamic` 解決を確認）
- `pytest` 164件 pass、`mypy --no-incremental` Success

## 補足

タグは現在1つも打たれていません（`git tag` が空）。この PR ではリポジトリの慣行に合わせて番号だけ上げています。`v1.0.0` を打つかどうかはご判断ください。CHANGELOG も無いので、必要なら別途用意します。
