### PR TITLE
docs: add a changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,132 @@
+# 変更履歴
+
+このファイルは md2pptx の変更を版ごとにまとめたものです。
+形式は [Keep a Changelog](https://keepachangelog.com/ja/1.1.0/) に、
+版番号は [Semantic Versioning](https://semver.org/lang/ja/) に従います。
+
+各項目の末尾の番号は Pull Request です。詳しい経緯はそちらを参照してください。
+
+## 1.0.0 — 2026-08-06
+
+記法が固まった版です。**同じことを言う方法が1つになりました**——スライドは見出しで分け、
+大きさは相対段数で指定し、見た目はテーマが決めます。
+
+これまでは表紙だけが例外で、「文書のメタデータ」の名前を持つ YAML キーに
+描画指示（`<br>` や `{±n}`）を書かせていました。記法が二重にあるので処理も二重になり、
+`<br>` を片方だけ通し忘れる取りこぼしまで起きています。旧記法は警告付きで動き続けます。
+
+### 追加
+
+- 表紙を本文記法で書けるようになりました。`# 主題` に `<!-- @layout: 0 -->` を添えます。
+  このレイアウトのスライドには番号が付きません [#89]
+- `<br>` の直後に相対サイズトークンを置けるようになりました。
+  その位置から先だけ大きさが変わります（副題をタイトル枠に収めるための記法）[#88]
+- 箇条書きマーカーだけの行が空行になります。記号の出ない枠で行の塊を分けられます [#86]
+- `<br>` を本文行でも使えるようになりました [#27]
+- 保存のたびに作り直す `--watch` [#54]
+- pptx の生成後に PDF を作れるようになりました。macOS では実 PowerPoint を裏で使います [#40][#41]
+- 変換の待ち時間に上限を設けました。tty なら打ち切りません [#51]
+
+### 変更
+
+- **破壊的**: `--pdf` をフラグにし、出力先を `--pdf-output PATH` へ分けました。
+  値を取るオプションだったため、`md2pptx --pdf 入力.md` が入力ファイルを
+  オプションの値として食べてしまっていました [#43]
+- **破壊的**: Python 3.11以上が必要になりました。3.9 は 2025-10-31 に
+  サポートが終わっています [#37]
+- フロントマターの `title` / `subtitle` / `author` / `affiliation` は**非推奨**です。
+  警告が出ますが、動作は従来どおりです [#89]
+- 全シグネチャに型注釈を必須化し、mypy を CI に入れました [#73][#74]
+
+### 修正
+
+- 相対サイズの基点が、実際に描かれる枠の既定を見ていませんでした。
+  同じ記法が同じ枠で違うサイズになっていました [#84]
+- 出力する文字に言語が付かず、日本語の禁則処理が効いていませんでした。
+  行頭に「ー」や句読点が来ることがありました [#80]
+- 本文を置く枠が無いテーマで、捨てた行を黙って落としていました [#68]
+- 出力 pptx と PDF を差し替え方式にしました。作り直している間に
+  壊れたファイルが見えることがありました [#53][#57]
+- PDF 変換中に PowerPoint の画面が出ないようにしました [#45]
+- 使い捨て作業ディレクトリの片付け規則を揃えました [#59]
+
+## 0.9.1 — 2026-07-22
+
+- フロー図の省略記号に固定幅の枠を割り当てるようにしました [#26]
+
+## 0.9.0 — 2026-07-22
+
+- ` ```note ` ブロックで発表者ノートを書けるようになりました [#24]
+
+## 0.8.0 — 2026-07-15
+
+- 表と画像のはみ出し指定を `<!-- @overflow: true -->` に統一しました [#23]
+
+## 0.7.0 — 2026-07-15
+
+- **破壊的**: Markdown 記法を整理しました。`@ph-widths` / `@body-width` は
+  `@widths` へ、`@col-widths` は `@table-widths` へ改名しています
+  （旧名称はエラーメッセージで新名称を案内します）[#22]
+
+## 0.6.0 — 2026-07-14
+
+- 多カラムスライド内の表でも列幅指定が効くようになりました [#21]
+
+## 0.5.0 — 2026-07-14
+
+- スライド単位でプレースホルダ幅を指定できるようになりました [#19]
+- 画像ブロックにはみ出し指定を追加しました [#16]
+
+## 0.4.0 — 2026-07-09
+
+- 表の区切り行のコロンから列ごとの水平寄せを読むようになりました [#15]
+
+## 0.3.0 — 2026-07-09
+
+- 多カラムスライドの中に表・画像・フロー図を置けるようになりました [#12]
+- `--version` を追加しました [#13]
+
+## 0.2.0 — 2026-07-02
+
+- 画像（jpg / png）をスライドに埋め込めるようになりました [#9]
+
+## 0.1.1 — 2026-07-01
+
+- フロントマターのタイトルスライドで相対サイズトークンを使えるようになりました [#6]
+
+## 0.1.0 — 2026-07-01
+
+- 最初の版。`pip` / `pipx` で入れられる `md2pptx` コマンドとして公開しました [#5]
+
+[#5]: https://github.com/toshi0806/md2pptx/pull/5
+[#6]: https://github.com/toshi0806/md2pptx/pull/6
+[#9]: https://github.com/toshi0806/md2pptx/pull/9
+[#12]: https://github.com/toshi0806/md2pptx/pull/12
+[#13]: https://github.com/toshi0806/md2pptx/pull/13
+[#15]: https://github.com/toshi0806/md2pptx/pull/15
+[#16]: https://github.com/toshi0806/md2pptx/pull/16
+[#19]: https://github.com/toshi0806/md2pptx/pull/19
+[#21]: https://github.com/toshi0806/md2pptx/pull/21
+[#22]: https://github.com/toshi0806/md2pptx/pull/22
+[#23]: https://github.com/toshi0806/md2pptx/pull/23
+[#24]: https://github.com/toshi0806/md2pptx/pull/24
+[#26]: https://github.com/toshi0806/md2pptx/pull/26
+[#27]: https://github.com/toshi0806/md2pptx/pull/27
+[#37]: https://github.com/toshi0806/md2pptx/pull/37
+[#40]: https://github.com/toshi0806/md2pptx/pull/40
+[#41]: https://github.com/toshi0806/md2pptx/pull/41
+[#43]: https://github.com/toshi0806/md2pptx/pull/43
+[#45]: https://github.com/toshi0806/md2pptx/pull/45
+[#51]: https://github.com/toshi0806/md2pptx/pull/51
+[#53]: https://github.com/toshi0806/md2pptx/pull/53
+[#54]: https://github.com/toshi0806/md2pptx/pull/54
+[#57]: https://github.com/toshi0806/md2pptx/pull/57
+[#59]: https://github.com/toshi0806/md2pptx/pull/59
+[#68]: https://github.com/toshi0806/md2pptx/pull/68
+[#73]: https://github.com/toshi0806/md2pptx/pull/73
+[#74]: https://github.com/toshi0806/md2pptx/pull/74
+[#80]: https://github.com/toshi0806/md2pptx/pull/80
+[#84]: https://github.com/toshi0806/md2pptx/pull/84
+[#86]: https://github.com/toshi0806/md2pptx/pull/86
+[#88]: https://github.com/toshi0806/md2pptx/pull/88
+[#89]: https://github.com/toshi0806/md2pptx/pull/89

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ python3 -m md2pptx input.md
 | 見た目を変える（配色・フォント・ロゴ・レイアウト） | [THEME.md](THEME.md) |
 | VS Code で編集しながらプレビューする | [VSCODE.md](VSCODE.md) |
 | 内部設計・記法の厳密仕様・再現検証結果 | [DESIGN.md](DESIGN.md) |
+| 版ごとの変更点 | [CHANGELOG.md](CHANGELOG.md) |
 
 ## コマンドラインリファレンス
 


### PR DESCRIPTION
## 概要

`CHANGELOG.md` を追加します。12版がリリース済みですが、各版で何が変わったかの記録が無く、`git log` を `__version__` の変更履歴と突き合わせないと分からない状態でした。

形式は [Keep a Changelog](https://keepachangelog.com/ja/1.1.0/)、版番号は Semantic Versioning に従います。README のドキュメント一覧にも1行足しました。

## 作り方

**版の境界と日付は `__version__` を設定したコミットから取りました。** そのコミットの1つ前の設定コミットまでが、その版に入った内容です。

```
2026-08-06  1.0.0   bbde2d8
2026-07-22  0.9.1   4812750
2026-07-22  0.9.0   a2a2f16
...
2026-07-01  0.1.0   3d1bf66
```

**PR 番号は commit と照合しました。** 最初の下書きでは commit メッセージの見た目から推測して**6件を間違えていました**。

| 項目 | 誤 | 正 |
|---|---|---|
| `<br>` を本文行でも | #28 | **#27** |
| `--watch` | #40 | **#54** |
| PDF 生成の土台 | #41 | **#40** |
| 実 PowerPoint での変換 | #44（存在しない） | **#41** |
| 変換の待ち時間の上限 | #49（存在しない） | **#51** |
| PDF の差し替え | #50（docs の PR） | **#53** |
| 画像の埋め込み | #8（Issue 番号） | **#9** |

`#44` と `#49` は CLAUDE.md に出てくる Issue 番号で、PR 番号ではありませんでした。`#8` も同様に Issue で、PR は `#9` です。

検証は次の3点で、いずれも通っています。

- 未定義の参照リンクが無い / 未参照の定義が無い
- 参照している番号がすべて commit（squash の `(#N)` または `Merge pull request #N`）に現れる
- 主要な PR はタイトルと merge 日を `gh pr view` で実物と突き合わせ

GitHub のレンダリングで素の `**` が0件、PR リンク30本と見出し15個が生成されることも確認しました。

## 補足

タグは別途 `v1.0.0` を打ちます（現在リポジトリにタグは1つもありません）。
