### PR TITLE
chore: release 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@
 
 各項目の末尾の番号は Pull Request です。詳しい経緯はそちらを参照してください。
 
+## 1.1.0 — 2026-08-06
+
+### 追加
+
+- 表紙を `<!-- @title-slide -->` で書けるようになりました。値を取らない指示で、
+  `@layout` との併記はエラーです [#95]
+
+### 変更
+
+- `---`（水平線）によるスライド分割は**非推奨**です。
+  行番号付きの警告が出ますが、動作は従来どおりです [#93]
+
 ## 1.0.0 — 2026-08-06
 
 記法が固まった版です。**同じことを言う方法が1つになりました**——スライドは見出しで分け、
@@ -130,3 +142,5 @@
 [#86]: https://github.com/toshi0806/md2pptx/pull/86
 [#88]: https://github.com/toshi0806/md2pptx/pull/88
 [#89]: https://github.com/toshi0806/md2pptx/pull/89
+[#93]: https://github.com/toshi0806/md2pptx/pull/93
+[#95]: https://github.com/toshi0806/md2pptx/pull/95

--- a/md2pptx/__init__.py
+++ b/md2pptx/__init__.py
@@ -5,6 +5,6 @@
 使う場合は parser.parse_file() で Deck を得て render.build() で描画できる．
 """
 
-__version__ = "1.0.0"
+__version__ = "1.1.0"
 
 __all__ = ["__version__"]


### PR DESCRIPTION
## 概要

`__version__` を 1.0.0 から **1.1.0** へ上げ、CHANGELOG に節を追加します。

## 1.1.0 とした根拠

1.0.0（#90）以降の変更は3件です。

```
docs: add a changelog (#91)
feat: deprecate '---' as a slide break (#92) (#93)
feat: write the title slide with @title-slide (#94) (#95)
```

**feat 2件、破壊的変更 0件**なので minor を上げます。

`---` の非推奨は破壊的変更**ではありません**。従来どおりスライドを分割し、描画も変わらず、行番号付きの警告が出るだけです。削除したときが破壊的変更になります。

## CHANGELOG

```markdown
## 1.1.0 — 2026-08-06

### 追加

- 表紙を `<!-- @title-slide -->` で書けるようになりました。値を取らない指示で、
  `@layout` との併記はエラーです [#95]

### 変更

- `---`（水平線）によるスライド分割は**非推奨**です。
  行番号付きの警告が出ますが、動作は従来どおりです [#93]
```

`docs: add a changelog`（#91）は CHANGELOG 自体を作った変更なので載せていません。

## 確認

- `md2pptx --version` → `md2pptx 1.1.0`（`pyproject.toml` は `dynamic` で `md2pptx.__version__` を参照）
- CHANGELOG のリンク検証：未定義の参照0件、未参照の定義0件、参照番号がすべて commit に存在
- `pytest` 177件 pass、`mypy --no-incremental` Success

## 補足

タグ `v1.1.0` は merge 後に別途打ちます。
