### PR TITLE
refactor: extract the layout primitives from flow.py

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -286,6 +286,43 @@ class Deck:
     slides: list[Slide] = field(default_factory=list)
 ```
 
+### 4.1 座標計算の共通プリミティブ（`layout.py`）
+
+図 DSL は「DSL を解釈して IR にする」と「IR を矩形領域へ置いて座標を出す」を分け、
+**座標計算まで純 Python（EMU 整数）で完結**させる。python-pptx を持ち込まないので、
+図の配置は pptx を書かずに試せる。`flow.py` がこの形で、新しい図 DSL も踏襲する。
+
+`layout.py` はその共通部分だけを持つ。
+
+| 名前 | 役割 |
+|---|---|
+| `EMU` / `emu(inch)` | 単位換算 |
+| `Rect` | 矩形。端と中心を**名前で**読む |
+| `PlacedNode` | 角丸四角ノード（色・サブラベルを持つので `node` ごと渡す） |
+| `PlacedText` | 文字だけの要素（省略記号・矢印ラベル・キャプション） |
+| `PlacedArrow` | 向きのある矢印 |
+| `PlacedLine` | 矢尻の無い線分（ライフラインなど）。`dashed` で破線 |
+
+**位置を名前で持つ。** 位置で持つと取り違えても誰も気づかない——幅と高さを
+入れ替えても、右端と下端を取り違えても、型としては同じ整数で通ってしまい、
+図が歪んで出てくるまで分からない（Issue #71）。
+
+図ごとの並べ方（何をどこに置くか）は各 DSL のモジュールが決める。
+
+#### `ObjectBlock` の判定は 1 か所
+
+`ir.is_object_block`（`TypeGuard`）が `ObjectBlock` の定義から実行時の判定を作る。
+それまで `(Table, Flow, Image)` というタプルが render の 5 か所
+（`render_slide` の単一カラム／多カラム、`_render_stacked_into`、`_obj_weight`、
+`_stack_objects`）に複製されており、**種類を増やすと必ずどこかが漏れる**形だった。
+
+#### 線を引く（`Renderer.line`）
+
+`block_arrow` はノード間の**すき間に収まる塗り矢印**で、太い直線＋三角矢じりが
+box に食い込むのを避けるための道具。`line` は任意の 2 点を結ぶ細い線で、
+シーケンス図のライフラインやメッセージのように**すき間ではなく図の骨格**を描く。
+`dashed` で破線、`arrow` で終点に矢じり（`a:tailEnd` を直接書く）。
+
 ## 5. Markdown 記法仕様
 
 ### 5.1 フロントマター（YAML）

--- a/README.md
+++ b/README.md
@@ -253,6 +253,7 @@ LaTeX Workshop のリアルタイムプレビューと同じ体験になりま�
 | `md2pptx/ir.py` | 中間表現のデータクラス定義 |
 | `md2pptx/render.py` | IR → pptx 描画 |
 | `md2pptx/flow.py` | フロー図 DSL のパーサ＋レイアウタ |
+| `md2pptx/layout.py` | 図の座標計算に共通の入れ物（矩形・配置結果）と単位換算 |
 | `md2pptx/pdf.py` | pptx → PDF 変換（`--pdf`） |
 | `md2pptx/watch.py` | 入力の変更監視（`--watch`） |
 | `md2pptx/workdir.py` | 使い捨て作業ディレクトリの作成と片付け |

--- a/md2pptx/flow.py
+++ b/md2pptx/flow.py
@@ -24,9 +24,7 @@ from dataclasses import dataclass, field
 from typing import Literal
 
 from .ir import Flow, FlowNode, FlowEdge
-from .layout import (
-    EMU, PlacedArrow, PlacedNode, PlacedText, Rect, emu as _emu,
-)
+from .layout import EMU, PlacedArrow, PlacedText, Rect, emu as _emu
 
 
 # 受理する値の集合．型付きなので "not in で弾いた残り" が Literal に絞られる
@@ -190,6 +188,17 @@ def _make_node(inner: str, color: str | None) -> FlowNode:
 # 描画指示（座標はすべて EMU 整数）．render はこれを読んで図形を置くだけで，
 # 位置の計算はここで終わっている．
 #
+@dataclass(frozen=True)
+class PlacedNode:
+    """角丸四角ノード．色・サブラベルを持つので ``node`` ごと渡す．
+
+    **``layout.py`` ではなくここに置く**——``FlowNode`` を抱えており flow 固有だから．
+    共通の入れ物に 1 つの DSL の型を持ち込むと、次の DSL が再利用できずに詰む．
+    """
+    node: FlowNode
+    rect: Rect
+
+
 @dataclass
 class FlowPlan:
     """図ひとつぶんの配置．

--- a/md2pptx/flow.py
+++ b/md2pptx/flow.py
@@ -24,18 +24,15 @@ from dataclasses import dataclass, field
 from typing import Literal
 
 from .ir import Flow, FlowNode, FlowEdge
+from .layout import (
+    EMU, PlacedArrow, PlacedNode, PlacedText, Rect, emu as _emu,
+)
 
-
-EMU = 914400  # 1 インチ = 914400 EMU
 
 # 受理する値の集合．型付きなので "not in で弾いた残り" が Literal に絞られる
 # （検証と型の単一の情報源にもなる）．
 _DIRECTIONS: tuple[Literal["lr", "tb"], ...] = ("lr", "tb")
 _NODE_KINDS: tuple[Literal["box", "ellipsis"], ...] = ("box", "ellipsis")
-
-
-def _emu(inch: float) -> int:
-    return int(inch * EMU)
 
 
 # 省略記号として扱うラベル．
@@ -193,58 +190,6 @@ def _make_node(inner: str, color: str | None) -> FlowNode:
 # 描画指示（座標はすべて EMU 整数）．render はこれを読んで図形を置くだけで，
 # 位置の計算はここで終わっている．
 #
-# 名前で持つのは，位置で持つと**取り違えても誰も気づかない**から．幅と高さを
-# 入れ替えても，右端と下端を取り違えても，型としては同じ整数で通ってしまい，
-# 図が歪んで出てくるまで分からない（Issue #71）．
-
-@dataclass(frozen=True)
-class Rect:
-    """矩形．端や中心は毎回足し算で出さず，ここから読む．"""
-    left: int
-    top: int
-    width: int
-    height: int
-
-    @property
-    def right(self) -> int:
-        return self.left + self.width
-
-    @property
-    def bottom(self) -> int:
-        return self.top + self.height
-
-    @property
-    def center_x(self) -> int:
-        return self.left + self.width // 2
-
-    @property
-    def center_y(self) -> int:
-        return self.top + self.height // 2
-
-
-@dataclass(frozen=True)
-class PlacedNode:
-    """角丸四角ノード．色・サブラベルを持つので ``node`` ごと渡す．"""
-    node: FlowNode
-    rect: Rect
-
-
-@dataclass(frozen=True)
-class PlacedText:
-    """文字だけの要素（省略記号・矢印ラベル・キャプション）．"""
-    text: str
-    rect: Rect
-
-
-@dataclass(frozen=True)
-class PlacedArrow:
-    """ノード間の矢印．始点から終点への線分で，太さは render が決める．"""
-    x1: int
-    y1: int
-    x2: int
-    y2: int
-
-
 @dataclass
 class FlowPlan:
     """図ひとつぶんの配置．

--- a/md2pptx/ir.py
+++ b/md2pptx/ir.py
@@ -250,7 +250,6 @@ def is_object_block(b: "Block") -> TypeGuard[ObjectBlock]:
     return isinstance(b, OBJECT_BLOCKS)
 
 
-
 @dataclass
 class Slide:
     """1 枚のコンテンツスライド．

--- a/md2pptx/ir.py
+++ b/md2pptx/ir.py
@@ -13,7 +13,7 @@ DESIGN.md §4 に対応．外部依存を持たない（python-pptx 等は impor
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Literal
+from typing import Literal, TypeGuard, get_args
 
 # 水平寄せ．表の列・画像の配置で共通に使う．
 Align = Literal["left", "center", "right"]
@@ -230,9 +230,25 @@ class Image:
 # だけを扱う（Line を渡すと属性が無く落ちる）．
 ObjectBlock = Table | Flow | Image
 
+# 実行時の判定用（``isinstance`` に渡せる形）．**ObjectBlock を増やしたら
+# ここだけ直せばよい**——render は 5 か所でこの判定をするので，型注釈と別に
+# タプルを書き並べると必ずどこかが漏れる（Issue #108）．
+OBJECT_BLOCKS: tuple[type, ...] = get_args(ObjectBlock)
+
 # スライド本文を構成するブロック．parser が出現順に並べ，render が型で分岐する．
 # Union は平坦化されるので Line | Table | Flow | Image と同一．
 Block = Line | ObjectBlock
+
+
+def is_object_block(b: "Block") -> TypeGuard[ObjectBlock]:
+    """帯へ座標配置するブロックか（``Line`` ではないか）を判定する．
+
+    ``isinstance`` を直に書くと ``(Table, Flow, Image)`` が render の 5 か所へ
+    散らばり，``ObjectBlock`` を増やしたときに必ずどこかが漏れる（Issue #108）．
+    ``TypeGuard`` にしてあるので型の絞り込みも効く．
+    """
+    return isinstance(b, OBJECT_BLOCKS)
+
 
 
 @dataclass

--- a/md2pptx/layout.py
+++ b/md2pptx/layout.py
@@ -6,8 +6,10 @@ flow / seq などの図 DSL は「DSL を解釈して IR にする」と「IR �
 置いて座標を出す」を分け、**座標計算まで純 Python（EMU 整数）で完結**させる。
 python-pptx を持ち込まないので、図の配置は pptx を書かずに試せる。
 
-このモジュールはその共通部分——単位換算と、置いた結果を表す入れ物だけを持つ。
-図ごとの並べ方（何をどこに置くか）は各 DSL のモジュールが決める。
+このモジュールはその共通部分——単位換算と、**どの DSL にも依存しない**幾何だけを持つ。
+図ごとの並べ方（何をどこに置くか）も、その DSL 固有のノードを抱える入れ物
+（flow の ``PlacedNode`` など）も、各 DSL のモジュールが持つ。
+ここに 1 つの DSL の型を持ち込むと、次の DSL がそれを再利用できずに詰む。
 
 **位置を名前で持つ。** 位置で持つと取り違えても誰も気づかない——幅と高さを
 入れ替えても、右端と下端を取り違えても、型としては同じ整数で通ってしまい、
@@ -16,8 +18,6 @@ python-pptx を持ち込まないので、図の配置は pptx を書かずに�
 from __future__ import annotations
 
 from dataclasses import dataclass
-
-from .ir import FlowNode
 
 EMU = 914400  # 1 インチ = 914400 EMU
 
@@ -50,13 +50,6 @@ class Rect:
     @property
     def center_y(self) -> int:
         return self.top + self.height // 2
-
-
-@dataclass(frozen=True)
-class PlacedNode:
-    """角丸四角ノード．色・サブラベルを持つので ``node`` ごと渡す．"""
-    node: FlowNode
-    rect: Rect
 
 
 @dataclass(frozen=True)

--- a/md2pptx/layout.py
+++ b/md2pptx/layout.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""図表の座標計算に共通のプリミティブ（md2pptx．DESIGN.md §4.1）．
+
+flow / seq などの図 DSL は「DSL を解釈して IR にする」と「IR を矩形領域へ
+置いて座標を出す」を分け、**座標計算まで純 Python（EMU 整数）で完結**させる。
+python-pptx を持ち込まないので、図の配置は pptx を書かずに試せる。
+
+このモジュールはその共通部分——単位換算と、置いた結果を表す入れ物だけを持つ。
+図ごとの並べ方（何をどこに置くか）は各 DSL のモジュールが決める。
+
+**位置を名前で持つ。** 位置で持つと取り違えても誰も気づかない——幅と高さを
+入れ替えても、右端と下端を取り違えても、型としては同じ整数で通ってしまい、
+図が歪んで出てくるまで分からない（Issue #71）。
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .ir import FlowNode
+
+EMU = 914400  # 1 インチ = 914400 EMU
+
+
+def emu(inch: float) -> int:
+    """インチを EMU 整数へ換算する．"""
+    return int(inch * EMU)
+
+
+@dataclass(frozen=True)
+class Rect:
+    """矩形．端や中心は毎回足し算で出さず，ここから読む．"""
+    left: int
+    top: int
+    width: int
+    height: int
+
+    @property
+    def right(self) -> int:
+        return self.left + self.width
+
+    @property
+    def bottom(self) -> int:
+        return self.top + self.height
+
+    @property
+    def center_x(self) -> int:
+        return self.left + self.width // 2
+
+    @property
+    def center_y(self) -> int:
+        return self.top + self.height // 2
+
+
+@dataclass(frozen=True)
+class PlacedNode:
+    """角丸四角ノード．色・サブラベルを持つので ``node`` ごと渡す．"""
+    node: FlowNode
+    rect: Rect
+
+
+@dataclass(frozen=True)
+class PlacedText:
+    """文字だけの要素（省略記号・矢印ラベル・キャプション）．"""
+    text: str
+    rect: Rect
+
+
+@dataclass(frozen=True)
+class PlacedArrow:
+    """要素どうしを結ぶ矢印．始点から終点への線分で，太さは render が決める．"""
+    x1: int
+    y1: int
+    x2: int
+    y2: int
+
+
+@dataclass(frozen=True)
+class PlacedLine:
+    """矢尻の無い線分（シーケンス図のライフラインなど）．
+
+    ``PlacedArrow`` と分けてあるのは**描き分けが要る**から——矢尻の有無は
+    見た目の差ではなく「向きがあるか」の差で、render はそれで図形を選ぶ。
+    ``dashed`` は破線（時間の経過や省略を表す線に使う）。
+    """
+    x1: int
+    y1: int
+    x2: int
+    y2: int
+    dashed: bool = False

--- a/md2pptx/render.py
+++ b/md2pptx/render.py
@@ -32,9 +32,10 @@ import sys
 from typing import TYPE_CHECKING, Any, Callable
 
 from pptx import Presentation
+from pptx.enum.dml import MSO_LINE_DASH_STYLE
 from pptx.enum.text import MSO_AUTO_SIZE, MSO_ANCHOR, PP_ALIGN
 from pptx.enum.dml import MSO_THEME_COLOR
-from pptx.enum.shapes import MSO_SHAPE
+from pptx.enum.shapes import MSO_CONNECTOR, MSO_SHAPE
 from pptx.oxml.ns import qn
 from pptx.util import Emu, Inches, Pt
 # python-pptx の Slide は ir.Slide と名前がぶつかる．**外来のほうに印を付ける**
@@ -44,6 +45,7 @@ from pptx.util import Emu, Inches, Pt
 # 注釈にはクラスのほうが要る．
 from pptx.presentation import Presentation as PptxPresentation
 from pptx.shapes.autoshape import Shape
+from pptx.shapes.connector import Connector
 from pptx.shapes.graphfrm import GraphicFrame
 from pptx.shapes.picture import Picture
 from pptx.shapes.placeholder import SlidePlaceholder
@@ -51,8 +53,8 @@ from pptx.slide import Slide as PptxSlide, SlideLayout
 from pptx.text.text import TextFrame
 
 from .ir import (
-    TITLE_LAYOUT, Block, Crop, Deck, Flow, Image, Length, Line, ObjectBlock,
-    Slide, Table, TitleSlide,
+    TITLE_LAYOUT, Block, Crop, Deck, Flow, Image, Length, Line, is_object_block,
+    ObjectBlock, Slide, Table, TitleSlide,
 )
 from .flow import FlowNode, plan_flow
 from . import workdir
@@ -673,6 +675,32 @@ class Renderer:
                     r.font.size = Pt(ssize)
         return shp
 
+    def line(self, slide: PptxSlide, x1: int, y1: int, x2: int, y2: int,
+             color: MSO_THEME_COLOR | None = None, width_pt: float = 1.0,
+             dashed: bool = False, arrow: bool = False) -> Connector:
+        """2 点を結ぶ線を引く（Issue #108）．
+
+        ``block_arrow`` はノード間の**すき間に収まる塗り矢印**で，box に食い込ませない
+        ための道具．こちらは任意の 2 点を結ぶ細い線で，シーケンス図のライフライン
+        （縦線）やメッセージ（斜めの矢印）のように**すき間ではなく図の骨格**を描くのに使う．
+
+        ``arrow`` を立てると終点に矢じりが付き，``dashed`` で破線になる
+        （時間の経過や省略を表す線に使う）．色はテーマ任せ（既定は本文色）．
+        """
+        conn = slide.shapes.add_connector(
+            MSO_CONNECTOR.STRAIGHT, Emu(int(x1)), Emu(int(y1)),
+            Emu(int(x2)), Emu(int(y2)))
+        conn.line.color.theme_color = color or self.TX
+        conn.line.width = Pt(width_pt)
+        if dashed:
+            conn.line.dash_style = MSO_LINE_DASH_STYLE.DASH
+        if arrow:
+            # 矢じりは python-pptx に API が無いので ``a:ln`` へ直接書く．
+            ln = conn.line._get_or_add_ln()
+            ln.append(ln.makeelement(qn("a:tailEnd"),
+                                     {"type": "triangle", "w": "med", "len": "med"}))
+        return conn
+
     def block_arrow(self, slide: PptxSlide, x1: int, y1: int, x2: int, y2: int,
                     thickness: int,
                     color: MSO_THEME_COLOR | None = None) -> Shape:
@@ -1134,7 +1162,7 @@ class Renderer:
             self._render_columns(s, slide.columns, default_num_color, scale,
                                  default_autofit, default_size_delta,
                                  self._col_ratios(directives), slide_overflow)
-        elif any(isinstance(b, (Table, Flow, Image)) for b in blocks):
+        elif any(is_object_block(b) for b in blocks):
             self._render_stacked(s, blocks, default_num_color, scale, default_autofit,
                                  self._col_ratios(directives), default_size_delta,
                                  slide_overflow)
@@ -1207,7 +1235,7 @@ class Renderer:
             ph = self._find_placeholder(slide, ci + 1)
             if ph is None:
                 continue  # レイアウトに該当プレースホルダが無ければスキップ
-            if any(isinstance(b, (Table, Flow, Image)) for b in col_blocks):
+            if any(is_object_block(b) for b in col_blocks):
                 # カラム矩形へ表・図をスタック配置．継承ジオメトリはレイアウトで補う．
                 # 通常 layout 3 は idx1/idx2 のジオメトリを持つため，解決失敗はテーマ
                 # 異常時のみ．その場合は本文領域へフォールバックする（表が消えるより，
@@ -1596,7 +1624,7 @@ class Renderer:
         prose_after: list[Line] = []
         seen_obj = False
         for b in blocks:
-            if isinstance(b, (Table, Flow, Image)):
+            if is_object_block(b):
                 if isinstance(b, Flow) and b.note_top:
                     bucket = prose_after if seen_obj else prose_before
                     bucket.append(self._note_to_line(b.note_top))

--- a/tests/test_layout_primitives.py
+++ b/tests/test_layout_primitives.py
@@ -97,6 +97,19 @@ def test_line_can_be_dashed_and_arrowed(tmp_path):
     assert "tailEnd" in xml
 
 
+def test_the_arrow_head_lands_on_the_end_point(tmp_path):
+    """矢じりが付くのは**終点**（``x2, y2`` 側）．
+
+    OOXML では ``a:headEnd`` が始点、``a:tailEnd`` が終点の装飾。取り違えると
+    矢印が逆を向くが、**線としては正しく引けてしまう**ので気づきにくい
+    （実 LibreOffice で右向きに出ることを目視でも確認した）。
+    """
+    r, slide = _slide(tmp_path)
+    xml = r.line(slide, 0, 0, emu(2), 0, arrow=True)._element.xml
+    assert "tailEnd" in xml
+    assert "headEnd" not in xml
+
+
 def test_a_plain_line_has_neither(tmp_path):
     """既定は実線・矢尻なし（ライフラインはこちら）．"""
     r, slide = _slide(tmp_path)

--- a/tests/test_layout_primitives.py
+++ b/tests/test_layout_primitives.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""座標計算の共通プリミティブと線ヘルパーを固定するテスト（Issue #108）．
+
+図 DSL を足すたびに ``Rect`` や ``Placed*`` を各モジュールで書き直すのは無駄だし、
+**``ObjectBlock`` を増やしたときの取りこぼし**が起きる——``(Table, Flow, Image)``
+というタプルが render の 5 か所に複製されていた。
+
+これは**機能を変えないリファクタ**なので、いちばん大事なのは「出力が変わらない」
+こと。ここでは移した先が使えることと、``is_object_block`` が
+``ObjectBlock`` の定義に自動で追従することを見る。
+
+``line`` は ``block_arrow`` と役割が違う。``block_arrow`` はノード間の**すき間に
+収まる塗り矢印**で box に食い込ませないための道具、``line`` は任意の 2 点を結ぶ
+細い線で、シーケンス図のライフラインのように**図の骨格**を描くためのもの。
+"""
+from __future__ import annotations
+
+from typing import get_args
+
+from pptx import Presentation
+
+from md2pptx import ir, render
+from md2pptx.flow import parse_flow, plan_flow
+from md2pptx.layout import EMU, PlacedLine, Rect, emu
+
+
+def test_rect_reads_its_edges_by_name():
+    """端と中心は名前で読む（足し算で出すと取り違えても気づけない）．"""
+    r = Rect(left=10, top=20, width=100, height=50)
+    assert (r.right, r.bottom) == (110, 70)
+    assert (r.center_x, r.center_y) == (60, 45)
+
+
+def test_emu_converts_inches():
+    assert emu(1) == EMU == 914400
+    assert emu(0.5) == 457200
+
+
+def test_flow_still_plans_through_the_shared_primitives():
+    """flow は移した先の ``Rect`` を使って従来どおり配置する．
+
+    移設で座標が変わっていないことが、このリファクタの受け入れ条件。
+    """
+    plan = plan_flow(parse_flow("[a] -> [b]"), 0, 0, emu(10), emu(5))
+    assert len(plan.boxes) == 2 and len(plan.arrows) == 1
+    first, second = (b.rect for b in plan.boxes)
+    assert isinstance(first, Rect)
+    assert first.left < second.left           # lr は左から右へ
+    assert first.center_y == second.center_y  # 高さは揃う
+
+
+def test_is_object_block_follows_the_type_alias():
+    """``is_object_block`` は ``ObjectBlock`` の定義に自動で追従する．
+
+    型注釈と別に ``(Table, Flow, Image)`` を書き並べると、種類を増やしたときに
+    必ずどこかが漏れる。**ここが漏れなければ render の 5 か所も漏れない**。
+    """
+    samples = {ir.Table: lambda: ir.Table(),
+               ir.Flow: lambda: ir.Flow(),
+               ir.Image: lambda: ir.Image(src="fig.png")}
+    kinds = get_args(ir.ObjectBlock)
+    # 種類が増えたらこのテストが先に落ちる（作り方を書き足せ、という合図）．
+    assert set(kinds) == set(samples), "ObjectBlock が増えた——見本を足すこと"
+    for cls in kinds:
+        assert ir.is_object_block(samples[cls]()), cls
+    assert not ir.is_object_block(ir.Line(text="ふつうの行"))
+
+
+def test_placed_line_carries_the_dashed_flag():
+    """``PlacedLine`` は破線かどうかを持つ（矢尻の有無は ``PlacedArrow`` と分ける）．"""
+    assert PlacedLine(0, 0, 10, 10).dashed is False
+    assert PlacedLine(0, 0, 10, 10, dashed=True).dashed is True
+
+
+def _slide(tmp_path):
+    theme = tmp_path / "theme.pptx"
+    Presentation().save(str(theme))
+    r = render.Renderer(str(theme))
+    return r, r.prs.slides.add_slide(r.L1)
+
+
+def test_line_draws_a_connector(tmp_path):
+    """``line`` は 2 点を結ぶ線を置く（塗り矢印ではない）．"""
+    r, slide = _slide(tmp_path)
+    before = len(slide.shapes)
+    r.line(slide, emu(1), emu(1), emu(3), emu(2))
+    assert len(slide.shapes) == before + 1
+
+
+def test_line_can_be_dashed_and_arrowed(tmp_path):
+    """破線と矢じりを指定できる（ライフラインとメッセージの描き分けに要る）．"""
+    r, slide = _slide(tmp_path)
+    conn = r.line(slide, 0, 0, emu(2), 0, dashed=True, arrow=True)
+    xml = conn._element.xml
+    assert "dash" in xml
+    assert "tailEnd" in xml
+
+
+def test_a_plain_line_has_neither(tmp_path):
+    """既定は実線・矢尻なし（ライフラインはこちら）．"""
+    r, slide = _slide(tmp_path)
+    xml = r.line(slide, 0, 0, emu(2), 0)._element.xml
+    assert "tailEnd" not in xml


### PR DESCRIPTION
Closes #108

**機能を変えないリファクタ**です。#109（flow の格子配置）と #110（`seq`）の下ごしらえ。

## 何をしたか

### 1. `layout.py` を新設して共通の入れ物を移した

`Rect` / `PlacedNode` / `PlacedText` / `PlacedArrow` と単位換算（`EMU` / `emu()`）が
`flow.py` の私有で、新しい図 DSL から再利用できなかった。

あわせて `PlacedLine`（矢尻なし・`dashed` 可）を足した。
シーケンス図のライフライン用。**矢尻の有無は見た目の差ではなく「向きがあるか」の差**で、
render はそれで図形を選ぶので `PlacedArrow` と分けている。

### 2. `ObjectBlock` の判定を1か所へ

`(Table, Flow, Image)` というタプルが render の**5か所**に複製されていた
（`render_slide` の単一カラム／多カラム、`_render_stacked_into`、`_obj_weight`、`_stack_objects`）。
**種類を増やすと必ずどこかが漏れる**形。

`ir.is_object_block` を `TypeGuard` で用意し、`ObjectBlock` の定義から実行時判定を作る。
`TypeGuard` にしたのは、単なる `tuple[type, ...]` だと mypy の絞り込みが効かなくなるため
（実際に一度落ちた）。

テストは `get_args(ObjectBlock)` と見本の集合が一致することを assert しているので、
**種類を増やすとこのテストが先に落ちて気づける**。

### 3. `Renderer.line` を足した

`block_arrow` はノード間の**すき間に収まる塗り矢印**で、太い直線＋三角矢じりが
box に食い込むのを避けるための道具。`line` は任意の2点を結ぶ細い線で、
シーケンス図のライフラインやメッセージのように**すき間ではなく図の骨格**を描く。

`dashed` で破線、`arrow` で終点に矢じり（python-pptx に API が無いので `a:tailEnd` を直接書く）。

## 出力が変わらないことの確認

これが本 PR の受け入れ条件なので、**`example.md` の出力をスライド XML の
バイト列で比較**した。

```
same file set: True
differing slide parts: none
```

- `pytest` 198件（新規8件）・`mypy` ともに通る
- `example.md` は無変更、CI の期待値も無変更

## 変更

| ファイル | 内容 |
|---|---|
| `md2pptx/layout.py` | **新規** |
| `md2pptx/flow.py` | 共通の入れ物を `layout` から import |
| `md2pptx/ir.py` | `OBJECT_BLOCKS` / `is_object_block` |
| `md2pptx/render.py` | 5か所の判定を一本化、`line` ヘルパー |
| `tests/test_layout_primitives.py` | 新規8件 |
| `DESIGN.md` §4.1 / `CHANGELOG.md` / `README.md` | 更新 |
