### PR TITLE
ci: run on integration branches and derive the PDF page count

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,12 @@ jobs:
         run: |
           test -f out.pdf
           slides=$(python -c "from pptx import Presentation; print(len(Presentation('out.pptx').slides))")
+          # 取り出せたことを先に確かめる．pdfinfo が成功しても awk が "Pages" を
+          # 見つけられなければ**空のまま終了コード 0** で通るので，set -e では
+          # 捕まらない．空のまま比べると「ページ数が違う」と読めてしまい，
+          # 原因が分かるログにするという目的（#120）が達せられない．
+          test -n "$slides" || { echo "ERROR: could not read the slide count from out.pptx"; exit 1; }
           pages=$(pdfinfo out.pdf | awk '/^Pages/{print $2}')
+          test -n "$pages" || { echo "ERROR: could not read the page count from out.pdf"; exit 1; }
           echo "slides=$slides pages=$pages"
           test "$pages" = "$slides"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,11 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    # main だけでなく統合ブランチ（feature/**）でも走らせる（Issue #121）．
+    # PR ごとの CI は「その PR の base に対して」通っただけで，**merge した後の
+    # 状態を検証していない**．衝突解消は人が手でやるのでいちばん壊れやすいのに，
+    # そこが誰にも検証されない状態だった．
+    branches: [main, 'feature/**']
   pull_request:
 
 concurrency:
@@ -97,9 +101,14 @@ jobs:
       - run: sudo apt-get update && sudo apt-get install -y libreoffice-impress poppler-utils
       - run: pip install -e .
       - run: md2pptx example.md --theme OfficeTheme.pptx -o out.pptx --pdf-output out.pdf --pdf-converter libreoffice
-      - name: Check the PDF was produced with the expected page count
+      # 期待値は**出力した pptx から引く**（Issue #120）．固定値を書くと，
+      # generate ジョブの枚数と 2 か所を直すことになり，片方を忘れると
+      # いちばん遅いこのジョブだけが後から落ちる（実際に3回落とした）．
+      # ここで見たいのは絶対枚数ではなく「PDF が全スライドを出力できたか」．
+      - name: Check the PDF has one page per slide
         run: |
           test -f out.pdf
+          slides=$(python -c "from pptx import Presentation; print(len(Presentation('out.pptx').slides))")
           pages=$(pdfinfo out.pdf | awk '/^Pages/{print $2}')
-          echo "pages=$pages"
-          test "$pages" = "19"
+          echo "slides=$slides pages=$pages"
+          test "$pages" = "$slides"


### PR DESCRIPTION
Closes #121
Closes #120

## なぜ1つの PR か

2件とも `ci.yml` の同じ領域を触るので、**別々の PR にすると確実に衝突します**。
今回の cn2026 対応では文書系ファイルの衝突解消で取りこぼしを何度も出しているので、
避けられる衝突は作らない方針にしました。

どちらも**今回の作業で実際に踏んだ穴**です。

## #121 統合ブランチに CI が走っていなかった

```yaml
on:
  push:
    branches: [main, 'feature/**']   # ← feature/** を追加
```

PR ごとの CI は「**その PR の base に対して**」通っただけで、
**merge した後の状態を検証していません**。衝突解消は人が手でやるので
いちばん壊れやすいのに、そこが誰にも検証されない状態でした。

実際、#117 の衝突解消で次が起きています。

| 症状 | 気づいた経緯 |
|---|---|
| `example.md` のデモが二重になり19枚が20枚に | 枚数が合わず見出しを手で数えた |
| `CHANGELOG.md` の「修正」節が2つ、項目重複 | 目視 |
| `README.md` の特徴に同じ行が2つ | `sort \| uniq -d` |
| `DESIGN.md` の §5.11 が §5.13 の後ろへ移動 | 節番号を grep |

`feature/**` にしておけば、今後の統合ブランチも名前を決めるだけで対象になります。
`concurrency: ci-${{ github.ref }}` は既にあるので、連続 merge で run は積み上がりません。

`AI Code Review` は `pull_request` 専用のままにしています（レビュー対象は PR の差分なので）。

## #120 PDF のページ数を固定値で持っていた

```yaml
- name: Check the PDF has one page per slide
  run: |
    test -f out.pdf
    slides=$(python -c "from pptx import Presentation; print(len(Presentation('out.pptx').slides))")
    pages=$(pdfinfo out.pdf | awk '/^Pages/{print $2}')
    echo "slides=$slides pages=$pages"
    test "$pages" = "$slides"
```

`example.md` の大きさが `generate` ジョブ（スライド枚数）と `pdf` ジョブ（ページ数）の
**2か所に固定値で**書かれており、同じ値なのに別々でした。片方を直し忘れると `pdf` だけが落ちます。

しかも `pdf` は LibreOffice のインストールから始まる**最も遅いジョブ**なので、
他が全部通った後に落ちます。**実際にこれで3回落としました**（#114 / #116 / #117）。

失敗時に `slides=` と `pages=` の**両方が出る**ので、何がずれたかもログで分かります。

### `generate` 側の固定値は残す

`assert len(p.slides) == 19` はそのままにしています。こちらは
「`example.md` が意図した枚数のデッキになるか」を見ており、
**`@step` の展開（1見出し → 3枚）のような記法側の退行を捕まえる**役目があります。
両方を pptx 由来にすると何も検証しなくなります。

## 確認

- YAML として妥当（`yaml.safe_load` で読めることを確認）
- **実 LibreOffice で新しいアサーションが通る**ことを確認（`slides=19 pages=19`）
- ページの過不足を**両方向で**検出できることを確認（18 でも 20 でも落ちる）
- この PR がマージされると、以降 `feature/lecture-slides` への merge で CI が走ります
