### PR TITLE
fix: 矢印の長手の比率を戻す（帯を分け合うと向きが読めなかった）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 
 ### 修正
 
+- 矢印を1枚に2つ置くと、どちらも小さすぎて向きが読めませんでした [#142]
 - 「白紙」レイアウトで図だけのスライドを作ると、**上にタイトルぶんの空きが
   残っていました**。タイトルの無いレイアウトでは空けなくなり、図が
   スライドいっぱいに置けます [#140]
@@ -243,3 +244,4 @@
 [#136]: https://github.com/toshi0806/md2pptx/pull/136
 [#139]: https://github.com/toshi0806/md2pptx/pull/139
 [#140]: https://github.com/toshi0806/md2pptx/pull/140
+[#142]: https://github.com/toshi0806/md2pptx/pull/142

--- a/md2pptx/render.py
+++ b/md2pptx/render.py
@@ -1952,7 +1952,10 @@ class Renderer:
         horizontal = arrow.direction in ("right", "left", "leftright")
         along = width if horizontal else height     # 矢印が伸びる向きの余地
         across = height if horizontal else width    # それと直交する向きの余地
-        long_ = min(Inches(0.9), max(Inches(0.3), int(along * 0.5)))
+        # 長手は自分の帯の 8 割．**ここを削ると矢印が向きを失う**——2 つ置いて
+        # 帯を分け合うと 1 つあたり 1.8cm ほどしか無く、半分では菱形に見える
+        # （Issue #141）．上限は元の講義スライドの大きさに合わせた．
+        long_ = min(Inches(1.0), max(Inches(0.3), int(along * 0.8)))
         short = min(int(across * 0.9), max(Inches(0.35), int(long_ * 0.75)))
         w, h = (long_, short) if horizontal else (short, long_)
         x = left + (width - w) // 2

--- a/tests/test_arrow_block.py
+++ b/tests/test_arrow_block.py
@@ -177,3 +177,18 @@ def test_a_repeated_key_takes_the_last_value():
     arrow, = [b for b in _blocks(
         "```arrow\ndirection: down\ndirection: up\n```") if isinstance(b, Arrow)]
     assert arrow.direction == "up"
+
+
+def test_two_arrows_stay_readable(tmp_path):
+    """帯を分け合っても、矢印が正方形（＝向きの読めない形）にならない．
+
+    #139 で長手の比率を落としたとき、2 つ置いた版が 0.89×0.89cm になり
+    ``updown`` が菱形に見えていた（Issue #141）。
+    """
+    src = (_FM + "### x\n\n- A\n  - a\n\n" + _fence("updown") + "\n\n- B\n  - b\n\n"
+           + _fence("down") + "\n\n→ C\n")
+    prs = _build(tmp_path, src)
+    slide = prs.slides[-1]
+    for kind in (MSO_SHAPE.UP_DOWN_ARROW, MSO_SHAPE.DOWN_ARROW):
+        arrow, = _shapes(slide, kind)
+        assert arrow.height > arrow.width * 1.2, f"{kind} が正方形に近い"

--- a/tests/test_arrow_block.py
+++ b/tests/test_arrow_block.py
@@ -189,6 +189,8 @@ def test_two_arrows_stay_readable(tmp_path):
            + _fence("down") + "\n\n→ C\n")
     prs = _build(tmp_path, src)
     slide = prs.slides[-1]
+    # ここで置くのは**縦向きだけ**なので「高さ＞幅」で見る．横向きを足すなら
+    # 向きごとに条件を分けること（長手がどちらかは render が決める）．
     for kind in (MSO_SHAPE.UP_DOWN_ARROW, MSO_SHAPE.DOWN_ARROW):
         arrow, = _shapes(slide, kind)
         assert arrow.height > arrow.width * 1.2, f"{kind} が正方形に近い"


### PR DESCRIPTION
Fixes #141

## 症状

1枚に矢印を2つ置くと、どちらも **0.89 × 0.89cm** になり、`updown` が菱形に見えて
向きが読めない（cn2025-01 s28「3.柔軟なネットワーク構造」の形）。

## 原因

**#139 で入れた退行。** 横向きの測り方を直したときに、縦向きの比率も一緒に変えていた。

```python
# #136（元）
long_ = min(Inches(0.75), max(Inches(0.3), int(height * 0.8)))

# #139（いま）— along/across を導入したときに 0.8 → 0.5 になった
long_ = min(Inches(0.9),  max(Inches(0.3), int(along  * 0.5)))
```

矢印が2つあると1つあたりの帯は 1.8cm ほどしかなく、その半分では下限の
`Inches(0.3)` にほぼ張り付く。

## 直し方

長手の比率を `0.8` に戻す。`along` / `across` の切り分け（#139 の本体）はそのまま。
上限は元の講義スライドの大きさ（`upDownArrow` が 2.5cm）に合わせて 1.0in にした。

```python
long_ = min(Inches(1.0), max(Inches(0.3), int(along * 0.8)))
```

## テスト

`test_two_arrows_stay_readable` を追加。帯を分け合っても縦横比が 1.2 倍以上あること
（＝正方形に近づかないこと）を見る。修正前は落ちる。

`pytest` 387件・`mypy` とも通過。

## 目視確認

cn2026-01 p.29 を実 PowerPoint で PDF 化して確認した。

| | 修正前 | 修正後 |
|---|--:|--:|
| `updown` | 0.89 × 0.89cm | **1.07 × 1.42cm** |

**なお、この PR とは別に cn2026-01 側も直した。** 元スライドは上下矢印の下に
さらに下向き矢印があるが、md2pptx の帯は**1スライドに1つ**なので、
地の文とオブジェクトを2回以上交互にはできない（2つ目の矢印が1つ目の隣に並ぶ）。
上下矢印だけ残すほうが読めるので、そうした。

https://claude.ai/code/session_0127SGeDYooTdMxAdXjeV8Ns
