### PR TITLE
chore: release 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,11 @@
 
 - **PDF 変換を独立パッケージ [pptx2pdf](https://github.com/toshi0806/pptx2pdf) へ移しました。**
   `--pdf` の使い方は変わりませんが、**依存が1つ増えたので入れ直しが要ります**
-  （`pip install -e .` などを流し直してください）。`pptx2pdf` は PyPI に出していないため
-  `pyproject.toml` は git の URL で指しています [#174]
+  （`pip install -e .` などを流し直してください）。
+  `pptx2pdf` は **PyPI に出していないので `pyproject.toml` は git の URL で指しています**。
+  そのため入れ直しには **git と GitHub への到達性が要ります**——git が無い環境や、
+  プロキシ・ファイアウォールで GitHub に出られない環境では解決に失敗します。
+  その場合は `pptx2pdf` を先に手元へ用意してから入れてください [#174]
 - **`md2pptx.pdf` モジュールが無くなりました。** ライブラリとして使っていた場合は
   `from md2pptx import pdf` を `from pptx2pdf import convert` に読み替えてください。
   `md2pptx.workdir` も同じく `pptx2pdf.workdir` へ移りました [#174]
@@ -348,9 +351,9 @@
 [#168]: https://github.com/toshi0806/md2pptx/pull/168
 [#170]: https://github.com/toshi0806/md2pptx/pull/170
 [#173]: https://github.com/toshi0806/md2pptx/pull/173
+[#174]: https://github.com/toshi0806/md2pptx/pull/174
 [#177]: https://github.com/toshi0806/md2pptx/pull/177
 [#179]: https://github.com/toshi0806/md2pptx/pull/179
 [#181]: https://github.com/toshi0806/md2pptx/pull/181
 [#183]: https://github.com/toshi0806/md2pptx/pull/183
 [#185]: https://github.com/toshi0806/md2pptx/pull/185
-[#174]: https://github.com/toshi0806/md2pptx/pull/174

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,23 @@
 
 各項目の末尾の番号は Pull Request です。詳しい経緯はそちらを参照してください。
 
-## 未リリース
+## 2.0.0 — 2026-09-03
+
+### 変更
+
+- **PDF 変換を独立パッケージ [pptx2pdf](https://github.com/toshi0806/pptx2pdf) へ移しました。**
+  `--pdf` の使い方は変わりませんが、**依存が1つ増えたので入れ直しが要ります**
+  （`pip install -e .` などを流し直してください）。`pptx2pdf` は PyPI に出していないため
+  `pyproject.toml` は git の URL で指しています [#174]
+- **`md2pptx.pdf` モジュールが無くなりました。** ライブラリとして使っていた場合は
+  `from md2pptx import pdf` を `from pptx2pdf import convert` に読み替えてください。
+  `md2pptx.workdir` も同じく `pptx2pdf.workdir` へ移りました [#174]
 
 ### 追加
 
 - ` ```arrow ` に `left:` を書けるようになりました。帯の左端からの距離で矢印を
   置きます（`3.33in` / `2cm` / `25%`）。`align` の 3 択では既存スライドの矢印の
   位置を写せませんでした [#181]
-
 - `<!-- @step -->` で段階表示ができるようになりました。1枚分の原稿から複数枚を作り、
   内容を積み上げて見せます。アニメーションの代わりに使えます。
   タイトル・レイアウト・ディレクティブは全段で共通で、発表者ノートは最終段だけに付きます [#114]
@@ -344,3 +353,4 @@
 [#181]: https://github.com/toshi0806/md2pptx/pull/181
 [#183]: https://github.com/toshi0806/md2pptx/pull/183
 [#185]: https://github.com/toshi0806/md2pptx/pull/185
+[#174]: https://github.com/toshi0806/md2pptx/pull/174

--- a/README.md
+++ b/README.md
@@ -58,7 +58,9 @@ pip install -e .
 > `python3 -m md2pptx …` でも実行できます。
 
 > 依存のひとつ [pptx2pdf](https://github.com/toshi0806/pptx2pdf)（`--pdf` の変換を担当）は
-> GitHub から取得します。インストール時に `git` とネットワークが要ります。
+> **PyPI に無く GitHub から取得します**。インストール時に `git` と GitHub への到達性が要ります。
+> プロキシやファイアウォールで出られない環境では解決に失敗するので、
+> その場合は `pptx2pdf` を先に手元へ用意してから `md2pptx` を入れてください。
 
 ## クイックスタート
 

--- a/md2pptx/__init__.py
+++ b/md2pptx/__init__.py
@@ -6,7 +6,7 @@
 """
 import pptx2pdf
 
-__version__ = "1.2.0"
+__version__ = "2.0.0"
 
 __all__ = ["__version__"]
 


### PR DESCRIPTION
## なぜ番号を上げるか

タグ `v1.2.0` 以降に **42 コミット**入っているのに `__version__` が `1.2.0` のままだった。
2 台のマシンで `md2pptx --version` がどちらも `1.2.0` を返しながら中身が違い、
**原稿が通らない原因の切り分けが git のリビジョン頼りになった**（`@table-width` /
`@title-width` / `@col: arrow` が古い側に無く、パースで落ちていた）。

## なぜ major か

`#174` が **PDF 変換を [pptx2pdf](https://github.com/toshi0806/pptx2pdf) へ分離**しており、
これが破壊的変更になっている。

| 変更 | 影響 |
|---|---|
| `md2pptx/pdf.py`（670行）を削除 | `from md2pptx import pdf` が壊れる |
| `md2pptx/workdir.py` を削除 | 同上（`pptx2pdf.workdir` へ移動） |
| `pptx2pdf` が必須依存に | **入れ直さないと `--pdf` が動かない**。PyPI に無く git URL 参照なので、解決に失敗する環境もありうる |

CLI の使い方は変わらないので 1.3.0 でも通せるが、**既存の環境が
「バージョンは同じなのに動かない」状態になる**のがまさに今回踏んだ問題なので、
番号で伝わるほうを採った。

## #174 が CHANGELOG に無かった

```
$ grep -n pptx2pdf CHANGELOG.md
（何も出ない）
```

依存が増える変更が記録されていなかった。`### 変更` として書き足し、
`from md2pptx import pdf` → `from pptx2pdf import convert` の読み替えも添えた。

## 中身

- `md2pptx/__init__.py` の `__version__` を `2.0.0` へ（`pyproject.toml` はここを参照）
- `CHANGELOG.md` の未リリース節を `## 2.0.0 — 2026-09-03` として確定。
  **変更 2 / 追加 14 / 修正 26 / 内部 1**
- `[#174]` のリンク定義を追加（未定義・未使用とも 0 で確認）

`pytest` 533件・`mypy` 通過。`python3 -m md2pptx --version` が `md2pptx 2.0.0` を返すことを確認。

## merge 後

`v2.0.0` のタグを打つ（既存のタグはすべて注釈付き `tag md2pptx X.Y.Z` の形）。

https://claude.ai/code/session_01W1pExPoAEUYeqzv2vd1FyR
